### PR TITLE
Add Zig-based glibc 2.17 linux/amd64 build to CI and document snapshot release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,14 +4,14 @@
 
 | File | Responsibility |
 |------|----------------|
-| `release.yml` | Runs tests, validates `.goreleaser.yml`, builds native release archives via `goreleaser build --single-target`, computes checksums, and publishes GitHub Releases on version tags. |
+| `release.yml` | Runs tests, validates `.goreleaser.yml`, builds release archives, computes checksums, and publishes GitHub Releases on version tags. |
 
 ## Notes
 
 - The release workflow is intentionally limited to the Phase 2 platform matrix:
   - `darwin/amd64` on `macos-15-intel`
   - `darwin/arm64` on `macos-14`
-  - `linux/amd64`
+  - `linux/amd64` (built with Zig target `x86_64-linux-gnu.2.17` for CentOS 7 / glibc 2.17 compatibility)
   - `linux/arm64`
 - Native GitHub runners are the only trusted multi-platform release path; local GoReleaser usage is limited to `goreleaser check` and optional single-target validation on the current host.
 - Publishing only happens for tag refs matching `v*`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,24 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Setup Zig for glibc 2.17 Linux amd64 build
+        if: matrix.goos == 'linux' && matrix.goarch == 'amd64'
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.0
       - name: Build archive
         shell: bash
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p dist
+
+          if [[ "${{ matrix.goos }}" == "linux" && "${{ matrix.goarch }}" == "amd64" ]]; then
+            export CC="zig cc -target x86_64-linux-gnu.2.17"
+            export CXX="zig c++ -target x86_64-linux-gnu.2.17"
+            export CGO_LDFLAGS="-static-libstdc++ -static-libgcc"
+          fi
+
           GOOS="${{ matrix.goos }}" GOARCH="${{ matrix.goarch }}" CGO_ENABLED=1 \
             go build -trimpath -ldflags "-s -w -X binlogviz/internal/version.Version=${VERSION}" -o dist/binlogviz .
           ARCHIVE="binlogviz_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz"

--- a/README.md
+++ b/README.md
@@ -121,27 +121,27 @@ Download the release archive for your platform from GitHub Releases, verify the 
 
 The authoritative release artifacts are produced by the GitHub Actions release workflow on native runners. Local `goreleaser` is intended for config validation and optional current-host checks, not as the primary release path.
 
-Example for `darwin/arm64` and the current release `v0.6.0`:
+Example for `darwin/arm64` and the current release `v0.8.0`:
 
 ```bash
-curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.6.0/binlogviz_0.6.0_darwin_arm64.tar.gz
-curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.6.0/binlogviz_0.6.0_checksums.txt
-shasum -a 256 -c binlogviz_0.6.0_checksums.txt 2>/dev/null | grep "binlogviz_0.6.0_darwin_arm64.tar.gz: OK"
-tar -xzf binlogviz_0.6.0_darwin_arm64.tar.gz
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.8.0/binlogviz_0.8.0_darwin_arm64.tar.gz
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.8.0/binlogviz_0.8.0_checksums.txt
+shasum -a 256 -c binlogviz_0.8.0_checksums.txt 2>/dev/null | grep "binlogviz_0.8.0_darwin_arm64.tar.gz: OK"
+tar -xzf binlogviz_0.8.0_darwin_arm64.tar.gz
 install ./binlogviz /usr/local/bin/binlogviz
 ```
 
 Or fetch the install helper from the same release tag before running it:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.6.0/install.sh
-sh ./install.sh --version v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.8.0/install.sh
+sh ./install.sh --version v0.8.0
 ```
 
 To preview the resolved artifact without downloading:
 
 ```bash
-./install.sh --version v0.6.0 --dry-run
+./install.sh --version v0.8.0 --dry-run
 ```
 
 ### Fallback: Build From Source

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -121,27 +121,27 @@ brew install --cask binlogviz
 
 权威 release artifact 由 GitHub Actions release workflow 在原生 runner 上构建。本地 `goreleaser` 更适合做配置校验和当前宿主机的可选验证，不是主要发布路径。
 
-下面是 `darwin/arm64` 和当前版本 `v0.6.0` 的示例：
+下面是 `darwin/arm64` 和当前版本 `v0.8.0` 的示例：
 
 ```bash
-curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.6.0/binlogviz_0.6.0_darwin_arm64.tar.gz
-curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.6.0/binlogviz_0.6.0_checksums.txt
-shasum -a 256 -c binlogviz_0.6.0_checksums.txt 2>/dev/null | grep "binlogviz_0.6.0_darwin_arm64.tar.gz: OK"
-tar -xzf binlogviz_0.6.0_darwin_arm64.tar.gz
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.8.0/binlogviz_0.8.0_darwin_arm64.tar.gz
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.8.0/binlogviz_0.8.0_checksums.txt
+shasum -a 256 -c binlogviz_0.8.0_checksums.txt 2>/dev/null | grep "binlogviz_0.8.0_darwin_arm64.tar.gz: OK"
+tar -xzf binlogviz_0.8.0_darwin_arm64.tar.gz
 install ./binlogviz /usr/local/bin/binlogviz
 ```
 
 也可以先从同一个 release tag 下载仓库内置安装脚本，再执行它：
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.6.0/install.sh
-sh ./install.sh --version v0.6.0
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.8.0/install.sh
+sh ./install.sh --version v0.8.0
 ```
 
 如果只想预览将要解析出的 artifact，而不实际下载：
 
 ```bash
-./install.sh --version v0.6.0 --dry-run
+./install.sh --version v0.8.0 --dry-run
 ```
 
 ### 备选：从源码构建

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1251,7 +1251,7 @@ It has published docs, explicit output contracts, release notes around HTML and 
           <div class="container">
             <p class="section-label" data-i18n="releases.label">Releases</p>
             <h2 class="section-title" data-i18n="releases.title">A short release arc that already explains the product direction</h2>
-            <p class="section-sub" data-i18n="releases.sub">The sequence matters: filters and analysis control first, then report exports, then visual compare.
+            <p class="section-sub" data-i18n="releases.sub">The sequence matters: filters and analysis control first, then report exports, visual compare, and snapshot workflows.
 That progression tells a better website story than raw feature lists alone.</p>
 
             <div class="split-grid">
@@ -1270,6 +1270,11 @@ That progression tells a better website story than raw feature lists alone.</p>
                   <div class="timeline-date">2026-04</div>
                   <div class="timeline-title" data-i18n="releases.items.reports.title">v0.7.0 — visual compare for incident review</div>
                   <div class="timeline-desc" data-i18n="releases.items.reports.desc">Compare turns two analyze JSON reports into text, JSON, and chart-based HTML deltas that teams can review together.</div>
+                </div>
+                <div class="timeline-item">
+                  <div class="timeline-date">2026-04</div>
+                  <div class="timeline-title" data-i18n="releases.items.snapshots.title">v0.8.0 — snapshot workflow for baseline comparisons</div>
+                  <div class="timeline-desc" data-i18n="releases.items.snapshots.desc">Snapshot save/list/show/delete workflows made baseline windows easier to preserve and compare without manual JSON path juggling.</div>
                 </div>
                 <div class="timeline-item">
                   <div class="timeline-date" data-i18n="releases.items.now.date">Now</div>
@@ -1506,11 +1511,12 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
           releases: {
             label: 'Releases',
             title: 'A short release arc that already explains the product direction',
-            sub: 'The sequence matters: filters and analysis control first, then report exports, then visual compare.\nThat progression tells a better website story than raw feature lists alone.',
+            sub: 'The sequence matters: filters and analysis control first, then report exports, visual compare, and snapshot workflows.\nThat progression tells a better website story than raw feature lists alone.',
             items: {
               filters: { title: 'v0.5.x — focus and control', desc: 'Time filters, object selectors, and better control over the incident analysis surface.' },
               exports: { title: 'v0.6.0 — report exports for handoff', desc: 'Markdown and HTML exports turned analysis results into artifacts that can move cleanly into docs, reviews, and browser-based sharing.' },
               reports: { title: 'v0.7.0 — visual compare for incident review', desc: 'Compare turns two analyze JSON reports into text, JSON, and chart-based HTML deltas that teams can review together.' },
+              snapshots: { title: 'v0.8.0 — snapshot workflow for baseline comparisons', desc: 'Snapshot save/list/show/delete workflows made baseline windows easier to preserve and compare without manual JSON path juggling.' },
               now: { date: 'Now', title: 'Clear DBA-first positioning', desc: 'A local CLI that explains workload shifts faster and hands the answer off cleanly.' }
             },
             side: {
@@ -1681,11 +1687,12 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
           releases: {
             label: '版本演进',
             title: '一条很短但已经足够说明方向的版本线',
-            sub: '顺序很重要：先有过滤和分析控制，再有报告导出，然后才是 visual compare。\n这个演进比单纯罗列功能更能支撑官网叙事。',
+            sub: '顺序很重要：先有过滤和分析控制，再有报告导出、visual compare，最后补齐 snapshot 工作流。\n这个演进比单纯罗列功能更能支撑官网叙事。',
             items: {
               filters: { title: 'v0.5.x —— 聚焦与控制', desc: '时间过滤、对象选择和更强的事故分析控制能力。' },
               exports: { title: 'v0.6.0 —— 面向交付的报告导出', desc: 'Markdown 和 HTML 导出把分析结果变成可以顺滑进入文档、评审和浏览器分享的交付物。' },
               reports: { title: 'v0.7.0 —— 面向事故评审的 visual compare', desc: 'compare 把两份 analyze JSON 报告变成 text、JSON 和图表化 HTML 差异视图，方便团队一起评审。' },
+              snapshots: { title: 'v0.8.0 —— 面向基线对比的 snapshot 工作流', desc: 'snapshot save/list/show/delete 让基线窗口的保存与复用更直接，不再依赖手工管理 JSON 路径。' },
               now: { date: '现在', title: '明确的 DBA-first 定位', desc: '一个本地 CLI，帮助团队更快解释负载变化，并把答案顺滑交给其他人。' }
             },
             side: {

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -993,7 +993,7 @@
         <section class="hero">
           <div class="container hero-content">
             <div class="hero-badge reveal visible">
-              <span class="eyebrow" data-i18n="hero.badge">v0.7.0 — visual compare + report exports</span>
+              <span class="eyebrow" data-i18n="hero.badge">v0.8.0 — snapshot + visual compare</span>
             </div>
             <h1 class="reveal visible" data-i18n="hero.title">Turn MySQL ROW binlogs
 into incident-ready reports</h1>
@@ -1410,7 +1410,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             homeLabel: 'BinlogViz home'
           },
           hero: {
-            badge: 'v0.7.0 — visual compare + report exports',
+            badge: 'v0.8.0 — snapshot + visual compare',
             title: 'Turn MySQL ROW binlogs\ninto incident-ready reports',
             sub: 'BinlogViz helps DBAs and on-call engineers move from raw binlog events to a readable workload story.\nFind hot tables, large transactions, write spikes, and incident-window changes, then compare the current window against a trusted baseline and hand the result to your team in a format they can actually use.',
             primary: 'Install BinlogViz',
@@ -1586,7 +1586,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             homeLabel: 'BinlogViz 首页'
           },
           hero: {
-            badge: 'v0.7.0 —— visual compare + 报告导出',
+            badge: 'v0.8.0 —— snapshot + visual compare',
             title: '把 MySQL ROW binlog\n变成可交付的事件报告',
             sub: 'BinlogViz 帮助 DBA 和值班工程师把原始 binlog 事件转成可读的工作负载故事。\n定位热点表、大事务、写入尖峰和事故窗口变化，再把当前窗口与可信基线做对比，然后以团队真正能消费的形式交付出去。',
             primary: '安装 BinlogViz',


### PR DESCRIPTION
### Motivation
- Ensure Linux amd64 release artifacts are built against glibc 2.17 for broader compatibility (CentOS 7 / glibc 2.17) by invoking Zig as the C compiler toolchain. 
- Make the project release story on the website reflect the new snapshot workflow milestone. 
- Keep the release workflow explicit about the platform matrix and how the linux/amd64 artifact is produced.

### Description
- Update `.github/workflows/release.yml` to conditionally install Zig using `mlugg/setup-zig@v2` for the `linux/amd64` matrix entry and set `version: 0.14.0`. 
- Add conditional environment exports in the build step to use `zig cc -target x86_64-linux-gnu.2.17` and `zig c++ -target x86_64-linux-gnu.2.17` as `CC`/`CXX` and set `CGO_LDFLAGS` to `-static-libstdc++ -static-libgcc` when building `linux/amd64`. 
- Tweak `.github/workflows/README.md` to describe the linux/amd64 build as being produced with the Zig target `x86_64-linux-gnu.2.17`. 
- Update `docs/landing/index.html` (and localized strings) to add a new `v0.8.0` release item and mention the `snapshot` workflow in the releases copy.

### Testing
- No automated tests were modified or run as part of this change. 
- Changes were limited to CI workflow configuration and website content updates, so verification should be performed by a CI run that exercises the `release` workflow on the matrix (which will install Zig and produce the glibc 2.17-linked linux/amd64 artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce35d8e7ec832e9c3d104dcda81aea)