### PR TITLE
Make analyze HTML an incident page that matches text findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,34 @@
 [![Changelog](https://img.shields.io/badge/Changelog-informational)](CHANGELOG.md) [![Security](https://img.shields.io/badge/Security-important)](SECURITY.md) [![Release Notes](https://img.shields.io/badge/Release_Notes-success)](docs/releases/)
 </div>
 
-BinlogViz is a local CLI for MySQL `ROW` binlog analysis. It is built for DBAs and operators who need to quickly answer practical questions from real binlog files: which tables are absorbing the most writes, which transactions are unusually large, where spikes happened, and how workload changed over a time window.
+BinlogViz reads a MySQL `ROW` binlog locally and turns it into an incident report: hottest tables, largest transactions, the peak write minute, and `file:pos` you can take back to `mysqlbinlog`.
+
+## Install
+
+macOS:
+
+```bash
+brew tap Fanduzi/binlogviz
+brew install --cask binlogviz
+```
+
+Linux / other (example: current release `v0.21.0` on `darwin/arm64`; pick the archive for your platform from [GitHub Releases](https://github.com/Fanduzi/BinlogVisualizer/releases)):
+
+```bash
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.21.0/binlogviz_0.21.0_darwin_arm64.tar.gz
+tar -xzf binlogviz_0.21.0_darwin_arm64.tar.gz
+install ./binlogviz /usr/local/bin/binlogviz
+```
+
+Checksum verification, `install.sh`, and source builds are in [Installation](#installation).
+
+## Screenshots
+
+Demo captures from a real `binlogviz analyze --format html` run are not in this repository yet. Add them here as:
+
+1. `docs/assets/html-incident.png` — HTML verdict and peak minute
+2. `docs/assets/html-tables.png` — hottest table and largest transaction with `file:pos`
+3. `docs/assets/text-findings.png` — matching text findings for the same input
 
 ## Start Here
 
@@ -149,7 +176,7 @@ binlogviz analyze mysql-bin.000123 --format html --output report.html
 binlogviz analyze mysql-bin.000123 --format html --output -
 ```
 
-The HTML report includes interactive charts (rows/txns per minute, top tables, operation mix), optional pattern drilldowns for high-signal write patterns, and a five-theme switcher.
+The HTML report opens as an incident page: a one-line verdict that matches the text findings, the peak minute and its tables, hottest table and largest transaction with `file:pos`, then charts and theme controls further down.
 
 ## Analyze Performance Gate
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -12,7 +12,34 @@
 [![变更记录](https://img.shields.io/badge/变更记录-informational)](CHANGELOG.md) [![安全策略](https://img.shields.io/badge/安全策略-important)](SECURITY.md) [![发行说明](https://img.shields.io/badge/发行说明-success)](docs/releases/)
 </div>
 
-BinlogViz 是一个面向 DBA 和运维人员的本地 MySQL `ROW` binlog 分析 CLI。它专门用于回答真实运维问题：哪些表写入最重、哪些事务异常大、尖峰发生在哪些分钟、某个故障窗口内的负载究竟发生了什么。
+BinlogViz 在本地读取 MySQL `ROW` binlog，并生成一份故障报告：最热的表、最大的事务、写入峰值分钟，以及可以带回 `mysqlbinlog` 的 `file:pos`。
+
+## 安装
+
+macOS：
+
+```bash
+brew tap Fanduzi/binlogviz
+brew install --cask binlogviz
+```
+
+Linux / 其他平台（示例：当前版本 `v0.21.0` 的 `darwin/arm64`；请从 [GitHub Releases](https://github.com/Fanduzi/BinlogVisualizer/releases) 选择对应平台的归档）：
+
+```bash
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.21.0/binlogviz_0.21.0_darwin_arm64.tar.gz
+tar -xzf binlogviz_0.21.0_darwin_arm64.tar.gz
+install ./binlogviz /usr/local/bin/binlogviz
+```
+
+checksum 校验、`install.sh` 和源码构建见 [安装说明](#安装说明)。
+
+## 截图
+
+真实 `binlogviz analyze --format html` 运行的演示截图尚未入库。准备好后放在这里：
+
+1. `docs/assets/html-incident.png` — HTML 结论和峰值分钟
+2. `docs/assets/html-tables.png` — 最热表、最大事务和 `file:pos`
+3. `docs/assets/text-findings.png` — 同一输入下对应的文本发现
 
 ## 从这里开始
 
@@ -149,7 +176,7 @@ binlogviz analyze mysql-bin.000123 --format html --output report.html
 binlogviz analyze mysql-bin.000123 --format html --output -
 ```
 
-HTML 报告包含交互式图表（每分钟行数/事务数、热点表、操作类型分布）、高信号写入模式的可选模式钻取（Pattern Drilldowns），以及五主题切换器。
+HTML 报告以故障页打开：一行结论与文本发现一致，接着是峰值分钟及其表、最热表和带 `file:pos` 的最大事务；图表和主题切换在更下方。
 
 ## Analyze 性能门槛
 
@@ -177,7 +204,7 @@ BinlogViz 重点服务这些 DBA 常见问题：
 - **当前窗口和可信基线相比，负载差异到底在哪里？**
 - **结果能否安全交给脚本、管道或其他工具？**
 
-## 安装
+## 安装说明
 
 ### macOS 首选：Homebrew Cask
 

--- a/cmd/binlogviz/analyze_product_test.go
+++ b/cmd/binlogviz/analyze_product_test.go
@@ -198,6 +198,160 @@ func TestAnalyzeCorpusTextAndHTMLContracts(t *testing.T) {
 	}
 }
 
+func TestWriteIncidentHTMLArtifacts(t *testing.T) {
+	if os.Getenv("WRITE_HTML_ARTIFACTS") == "" {
+		t.Skip("set WRITE_HTML_ARTIFACTS=1 to dump inspectable HTML reports")
+	}
+	forceEnglishRuntimeOutput(t)
+	dir := os.Getenv("WRITE_HTML_ARTIFACTS_DIR")
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, scenario := range []string{"tps-spike", "rows-spike", "baseline-small"} {
+		htmlOut, err := report.RenderHTML(analyzeCorpus(t, scenario))
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, scenario+".html")
+		if err := os.WriteFile(path, []byte(htmlOut), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s", path)
+	}
+
+	tiny := screenshotLikeTinyResult()
+	htmlOut, err := report.RenderHTML(tiny)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "screenshot-like-tiny.html")
+	if err := os.WriteFile(path, []byte(htmlOut), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("wrote %s", path)
+}
+
+func screenshotLikeTinyResult() model.AnalysisResult {
+	start := time.Date(2026, 3, 15, 14, 10, 26, 0, time.UTC)
+	return model.AnalysisResult{
+		Summary: model.WorkloadSummary{
+			TotalTransactions: 4,
+			TotalRows:         5,
+			TotalEvents:       16,
+			StartTime:         start,
+			EndTime:           start,
+			Duration:          0,
+		},
+		Tables: []model.TableStats{{
+			Schema: "shop", Table: "orders", TotalRows: 5, InsertRows: 3, UpdateRows: 2, TxnCount: 4, EventCount: 8,
+		}},
+		Minutes: []model.MinuteBucket{{
+			Minute: start, TotalRows: 5, TxnCount: 4, EventCount: 16,
+			TableRows: map[string]int{"shop.orders": 5},
+		}},
+		Diagnostics: model.Diagnostics{
+			HotIntervals: []model.MinuteBucket{{
+				Minute: start, TotalRows: 5, TxnCount: 4, EventCount: 16,
+				TableRows: map[string]int{"shop.orders": 5},
+			}},
+			LargestTransactions: []model.Transaction{{
+				TxnKey:          "txn-1",
+				TotalRows:       2,
+				Operations:      map[string]int{"INSERT": 2},
+				Tables:          map[string]int{"shop.orders": 2},
+				QuerySummary:    "INSERT INTO shop.orders ...",
+				BinlogPathStart: "mysql-bin.000123",
+				BinlogPathEnd:   "mysql-bin.000123",
+				PositionStart:   240,
+				PositionEnd:     480,
+			}},
+		},
+	}
+}
+
+func TestAnalyzeCorpusHTMLIncidentFirstScreenMatchesText(t *testing.T) {
+	forceEnglishRuntimeOutput(t)
+
+	for _, scenario := range []string{"tps-spike", "rows-spike", "baseline-small"} {
+		t.Run(scenario, func(t *testing.T) {
+			result := analyzeCorpus(t, scenario)
+			textOut, err := report.RenderText(result)
+			if err != nil {
+				t.Fatalf("render text: %v", err)
+			}
+			htmlOut, err := report.RenderHTML(result)
+			if err != nil {
+				t.Fatalf("render html: %v", err)
+			}
+
+			if strings.Contains(htmlOut, "workload looks healthy") {
+				t.Fatalf("HTML first screen still claims healthy\n%s", htmlOut)
+			}
+
+			assertIncidentHeaderBeforeChrome(t, htmlOut)
+
+			for _, line := range textFindingLines(textOut) {
+				if !strings.Contains(htmlOut, stripFindingPrefix(line)) {
+					t.Fatalf("HTML missing text finding %q", line)
+				}
+			}
+		})
+	}
+}
+
+func textFindingLines(textOut string) []string {
+	var lines []string
+	inFindings := false
+	for _, line := range strings.Split(textOut, "\n") {
+		if strings.HasPrefix(line, "=== ") {
+			inFindings = strings.Contains(line, "Top Findings")
+			continue
+		}
+		if !inFindings {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			break
+		}
+		lines = append(lines, trimmed)
+	}
+	return lines
+}
+
+func stripFindingPrefix(line string) string {
+	// "[critical] Write spike at ..." -> "Write spike at ..."
+	if i := strings.Index(line, "] "); i >= 0 {
+		return line[i+2:]
+	}
+	return line
+}
+
+func assertIncidentHeaderBeforeChrome(t *testing.T, htmlOut string) {
+	t.Helper()
+	verdictIdx := strings.Index(htmlOut, `id="incident-verdict"`)
+	themeIdx := strings.Index(htmlOut, `class="theme-switcher"`)
+	tpsIdx := strings.Index(htmlOut, `id="chart-tps"`)
+	if verdictIdx < 0 || themeIdx < 0 || tpsIdx < 0 {
+		t.Fatal("expected verdict, theme switcher, and TPS chart")
+	}
+	if verdictIdx > themeIdx || verdictIdx > tpsIdx {
+		t.Fatalf("verdict must appear before theme switcher and TPS chart")
+	}
+	for _, id := range []string{`id="peak-minute"`, `id="hottest-table"`, `id="largest-txn"`} {
+		idx := strings.Index(htmlOut, id)
+		if idx < 0 {
+			t.Fatalf("expected incident header %s", id)
+		}
+		if idx > themeIdx || idx > tpsIdx {
+			t.Fatalf("%s must appear before theme switcher and TPS chart", id)
+		}
+	}
+}
+
 func TestAnalyzeCorpusTextAndHTMLShareTopTableLimit(t *testing.T) {
 	forceEnglishRuntimeOutput(t)
 

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -509,7 +509,43 @@
   },
   "report.html.analyze.executiveSummary": {
     "description": "Analyze executive summary section header",
-    "other": "Executive Summary"
+    "other": "Incident"
+  },
+  "report.html.analyze.verdict": {
+    "description": "One-line HTML incident verdict label",
+    "other": "Verdict"
+  },
+  "report.html.analyze.peakMinute": {
+    "description": "Peak write-minute card title",
+    "other": "Peak Minute"
+  },
+  "report.html.analyze.tablesInPeakMinute": {
+    "description": "Tables contributing rows in the peak minute",
+    "other": "Tables in this minute"
+  },
+  "report.html.analyze.vsWindowMedian": {
+    "description": "Peak rows compared with median of other minutes",
+    "other": "vs window median"
+  },
+  "report.html.analyze.vsSpikeBaseline": {
+    "description": "Peak rows compared with analyzer spike baseline",
+    "other": "vs spike baseline"
+  },
+  "report.html.analyze.hottestTable": {
+    "description": "Hottest table card title",
+    "other": "Hottest Table"
+  },
+  "report.html.analyze.querySummary": {
+    "description": "Bounded SQL or annotate summary label",
+    "other": "SQL / annotate"
+  },
+  "report.html.analyze.theme": {
+    "description": "Footer theme switcher label",
+    "other": "Theme"
+  },
+  "report.html.analyze.factor": {
+    "description": "Peak-to-baseline factor label",
+    "other": "factor"
   },
   "report.html.analyze.activityCharts": {
     "description": "Analyze activity charts section header",
@@ -1117,6 +1153,6 @@
   },
   "report.html.analyze.noAlerts": {
     "description": "No alerts empty state",
-    "other": "No issues detected — workload looks healthy"
+    "other": "No high-signal findings detected."
   }
 }

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1115,6 +1115,10 @@
     "description": "Binlog span label",
     "other": "Binlog Span"
   },
+  "report.html.analyze.xidOnlySpan": {
+    "description": "Honest note when the analyzer only recorded a commit XID interval",
+    "other": "Recorded span is XID-only ({{.Bytes}} B); not a usable --start-position"
+  },
   "report.html.analyze.widestTag": {
     "description": "Widest transaction tag",
     "other": "widest"

--- a/internal/i18n/locales/zh-CN.json
+++ b/internal/i18n/locales/zh-CN.json
@@ -1115,6 +1115,10 @@
     "description": "Binlog 跨度标签",
     "other": "Binlog 跨度"
   },
+  "report.html.analyze.xidOnlySpan": {
+    "description": "分析器只记下提交 XID 区间时的诚实说明",
+    "other": "记录到的跨度只是 XID（{{.Bytes}} 字节），不能当作 --start-position"
+  },
   "report.html.analyze.widestTag": {
     "description": "最宽事务标签",
     "other": "最宽"

--- a/internal/i18n/locales/zh-CN.json
+++ b/internal/i18n/locales/zh-CN.json
@@ -508,8 +508,44 @@
     "other": "分析报告"
   },
   "report.html.analyze.executiveSummary": {
-    "description": "Analyze 执行摘要章节标题",
-    "other": "执行摘要"
+    "description": "Analyze 故障摘要章节标题",
+    "other": "故障摘要"
+  },
+  "report.html.analyze.verdict": {
+    "description": "HTML 故障页一行结论标签",
+    "other": "结论"
+  },
+  "report.html.analyze.peakMinute": {
+    "description": "峰值写入分钟卡片标题",
+    "other": "峰值分钟"
+  },
+  "report.html.analyze.tablesInPeakMinute": {
+    "description": "峰值分钟内贡献行数的表",
+    "other": "该分钟的表"
+  },
+  "report.html.analyze.vsWindowMedian": {
+    "description": "峰值行数与其余分钟中位数对比",
+    "other": "对比窗口中位数"
+  },
+  "report.html.analyze.vsSpikeBaseline": {
+    "description": "峰值行数与尖峰检测基线对比",
+    "other": "对比尖峰基线"
+  },
+  "report.html.analyze.hottestTable": {
+    "description": "最热表卡片标题",
+    "other": "最热表"
+  },
+  "report.html.analyze.querySummary": {
+    "description": "有界 SQL 或 annotate 摘要标签",
+    "other": "SQL / annotate"
+  },
+  "report.html.analyze.theme": {
+    "description": "页脚主题切换标签",
+    "other": "主题"
+  },
+  "report.html.analyze.factor": {
+    "description": "峰值相对基线倍数标签",
+    "other": "倍数"
   },
   "report.html.analyze.activityCharts": {
     "description": "Analyze 活动图表章节标题",
@@ -1117,6 +1153,6 @@
   },
   "report.html.analyze.noAlerts": {
     "description": "无告警空状态",
-    "other": "未发现问题 — 负载看起来健康"
+    "other": "未检测到高信号发现。"
   }
 }

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -46,4 +46,6 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 - The HTML renderer keeps activity charts readable on large reports by using a larger responsive grid and suppressing non-essential legends that can overlap chart content.
 - The HTML renderer follows an incident reading path: one-line verdict (same findings as text), peak minute with that minute's tables, hottest table and largest transaction, remaining findings, hot objects, diagnostic evidence, then demoted activity charts. Theme switchers sit in the footer.
 - HTML never treats an empty `alerts` slice as a healthy workload. It renders `collectDisplayFindings`, which matches the text Top Findings list (diagnostics findings, then a synthesized write spike / longest txn / DDL).
+- Rollback hints use `firstUsableRollbackLocation`. A recorded 31-byte XID interval (dogfood #18) is shown as an XID-only span and is not offered as `--start-position`. The renderer does not invent a real start pos.
+- Pattern drilldown representative transactions stay a static list. The incident page does not add a click path onto those keys (dogfood #20).
 - Transaction evidence in HTML highlights the single current champion for largest, longest, and widest transactions instead of rendering a crowded top-N list.

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -8,11 +8,12 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 |------|----------------|
 | `options.go` | Defines renderer presentation controls, including `summary/off/full` SQL context modes. |
 | `product.go` | Owns shared report presentation defaults and metric labels used by all renderers. |
+| `findings.go` | Builds the shared Top Findings list used by text and HTML so both stay in parity. |
 | `text.go` | Renders the concise diagnostic text report plus opt-in minute and write-shape detail sections. |
 | `json.go` | Serializes the stable analyze JSON report shape, including optional top-level snapshot metadata, and applies SQL context field visibility rules. |
 | `markdown.go` | Renders GitHub-flavored Markdown output. |
-| `html.go` | Renders the self-contained HTML report, including responsive activity-chart layout and ECharts data preparation. |
-| `*_test.go` | Verifies diagnostic text defaults, opt-in detail sections, JSON field stability, snapshot behavior, and SQL context mode behavior. |
+| `html.go` | Renders the self-contained HTML incident page, including peak-minute evidence and demoted ECharts. |
+| `*_test.go` | Verifies diagnostic text defaults, findings parity, opt-in detail sections, JSON field stability, snapshot behavior, and SQL context mode behavior. |
 
 ## Interfaces
 
@@ -43,5 +44,6 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 - Text rendering is intentionally kept on a fast path: it must not build HTML chart data, read embedded ECharts assets, or render pattern drilldowns unless detail options request them.
 - The JSON renderer omits `snapshot` entirely when `AnalysisResult.Snapshot` is nil, preserving legacy analyze JSON shape.
 - The HTML renderer keeps activity charts readable on large reports by using a larger responsive grid and suppressing non-essential legends that can overlap chart content.
-- The HTML renderer now follows a DBA reading path: executive summary (with key findings strip), risks & findings, activity overview, hot objects, then diagnostic evidence (transaction evidence, DDL timeline, pattern drilldowns, file coverage, binlog throughput).
+- The HTML renderer follows an incident reading path: one-line verdict (same findings as text), peak minute with that minute's tables, hottest table and largest transaction, remaining findings, hot objects, diagnostic evidence, then demoted activity charts. Theme switchers sit in the footer.
+- HTML never treats an empty `alerts` slice as a healthy workload. It renders `collectDisplayFindings`, which matches the text Top Findings list (diagnostics findings, then a synthesized write spike / longest txn / DDL).
 - Transaction evidence in HTML highlights the single current champion for largest, longest, and widest transactions instead of rendering a crowded top-N list.

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -44,6 +44,7 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 - Text rendering is intentionally kept on a fast path: it must not build HTML chart data, read embedded ECharts assets, or render pattern drilldowns unless detail options request them.
 - The JSON renderer omits `snapshot` entirely when `AnalysisResult.Snapshot` is nil, preserving legacy analyze JSON shape.
 - The HTML renderer keeps activity charts readable on large reports by using a larger responsive grid and suppressing non-essential legends that can overlap chart content.
+- TPS/min and rows-per-minute keep a visible circle (size 10) when a series has fewer than 2 points so a Duration-0s / single-minute report does not render an empty polyline.
 - The HTML renderer follows an incident reading path: one-line verdict (same findings as text), peak minute with that minute's tables, hottest table and largest transaction, remaining findings, hot objects, diagnostic evidence, then demoted activity charts. Theme switchers sit in the footer.
 - HTML never treats an empty `alerts` slice as a healthy workload. It renders `collectDisplayFindings`, which matches the text Top Findings list (diagnostics findings, then a synthesized write spike / longest txn / DDL).
 - Rollback hints use `firstUsableRollbackLocation`. A recorded 31-byte XID interval (dogfood #18) is shown as an XID-only span and is not offered as `--start-position`. The renderer does not invent a real start pos.

--- a/internal/report/findings.go
+++ b/internal/report/findings.go
@@ -1,0 +1,93 @@
+// Package report shares the analyze finding list used by text and HTML renderers.
+// input: analyzer-produced AnalysisResult values plus the report Top-N limit.
+// output: the same bounded display findings the text report prints under Top Findings.
+// pos: single source of truth so HTML never calls an empty alerts list "healthy".
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"fmt"
+	"strings"
+
+	"binlogviz/internal/i18n"
+	"binlogviz/internal/model"
+)
+
+// displayFinding is one user-visible finding line shared by text and HTML.
+type displayFinding struct {
+	Severity string
+	Message  string
+}
+
+// collectDisplayFindings returns the same findings the text report prints.
+// It prefers diagnostics findings, then fills remaining slots from the
+// busiest hot interval, longest transaction, and first DDL event.
+func collectDisplayFindings(result model.AnalysisResult, limit int) []displayFinding {
+	if limit <= 0 {
+		return nil
+	}
+
+	out := make([]displayFinding, 0, limit)
+	for _, finding := range result.Diagnostics.Findings {
+		out = append(out, displayFinding{Severity: finding.Severity, Message: finding.Message})
+		if len(out) >= limit {
+			return out
+		}
+	}
+
+	if len(out) < limit && len(result.Diagnostics.HotIntervals) > 0 {
+		hot := result.Diagnostics.HotIntervals[0]
+		out = append(out, displayFinding{
+			Severity: "critical",
+			Message: fmt.Sprintf("%s at %s: rows=%d, txns=%d",
+				i18n.T("report.text.writeSpike"),
+				hot.Minute.Format("2006-01-02 15:04"),
+				hot.TotalRows,
+				hot.TxnCount),
+		})
+	}
+
+	if len(out) < limit && len(result.Diagnostics.LongestTransactions) > 0 {
+		txn := result.Diagnostics.LongestTransactions[0]
+		out = append(out, displayFinding{
+			Severity: "warning",
+			Message: fmt.Sprintf("%s: %s, rows=%d, tables=%d, file=%s",
+				i18n.T("report.text.longestTransaction"),
+				formatDuration(txn.Duration),
+				txn.TotalRows,
+				len(txn.Tables),
+				formatSuspiciousLocation(txn),
+			),
+		})
+	}
+
+	if len(out) < limit && len(result.Diagnostics.DDLEvents) > 0 {
+		ddl := result.Diagnostics.DDLEvents[0]
+		target := strings.Trim(strings.TrimSpace(ddl.Schema+"."+ddl.Table), ".")
+		if target == "" {
+			target = ddl.Object
+		}
+		out = append(out, displayFinding{
+			Severity: "warning",
+			Message: fmt.Sprintf("%s: %s %s at %s",
+				i18n.T("report.text.ddlDetected"),
+				ddl.Operation,
+				target,
+				ddl.Timestamp.Format("2006-01-02 15:04"),
+			),
+		})
+	}
+
+	return out
+}
+
+func findingBadge(severity string) string {
+	switch severity {
+	case "warning":
+		return "WARN"
+	case "critical":
+		return "CRIT"
+	default:
+		return "INFO"
+	}
+}

--- a/internal/report/findings_test.go
+++ b/internal/report/findings_test.go
@@ -1,0 +1,156 @@
+// Package report verifies text and HTML share the same analyze findings list.
+// input: synthetic AnalysisResult values with empty alerts plus a hot-interval spike.
+// output: assertions that HTML verdict/findings match the text Top Findings lines.
+// pos: regression coverage for the empty-alerts-vs-synthesized-spike mismatch.
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"binlogviz/internal/model"
+)
+
+func TestCollectDisplayFindingsMatchesTextTopFindings(t *testing.T) {
+	result := productTextFixture()
+	if len(result.Alerts) != 0 {
+		t.Fatal("fixture must keep alerts empty so the synthesized spike path is exercised")
+	}
+
+	textOut, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("RenderText() error: %v", err)
+	}
+	findings := collectDisplayFindings(result, DefaultTopN)
+	if len(findings) == 0 {
+		t.Fatal("expected synthesized findings from hot interval / txn / DDL")
+	}
+	if findings[0].Severity != "critical" || !strings.Contains(findings[0].Message, "Write spike") {
+		t.Fatalf("expected first finding to be a critical write spike, got %+v", findings[0])
+	}
+	for _, finding := range findings {
+		line := fmt.Sprintf("[%s] %s", finding.Severity, finding.Message)
+		if !strings.Contains(textOut, line) {
+			t.Fatalf("text report missing finding %q\n%s", line, textOut)
+		}
+	}
+}
+
+func TestRenderHTMLFindingsParityWithText(t *testing.T) {
+	result := productTextFixture()
+
+	textOut, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("RenderText() error: %v", err)
+	}
+	htmlOut, err := RenderHTML(result)
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+
+	if strings.Contains(htmlOut, "workload looks healthy") {
+		t.Fatalf("HTML called an empty alerts list healthy while text has findings\n%s", htmlOut)
+	}
+
+	findings := collectDisplayFindings(result, DefaultTopN)
+	if len(findings) == 0 {
+		t.Fatal("expected findings")
+	}
+	verdictIdx := strings.Index(htmlOut, `id="incident-verdict"`)
+	if verdictIdx < 0 {
+		t.Fatal("expected incident verdict")
+	}
+	if !strings.Contains(htmlOut[verdictIdx:], findings[0].Message) {
+		t.Fatalf("HTML verdict missing first text finding %q", findings[0].Message)
+	}
+	for _, finding := range findings {
+		if !strings.Contains(htmlOut, finding.Message) {
+			t.Fatalf("HTML missing text finding %q", finding.Message)
+		}
+		line := fmt.Sprintf("[%s] %s", finding.Severity, finding.Message)
+		if !strings.Contains(textOut, line) {
+			t.Fatalf("text missing finding %q\n%s", line, textOut)
+		}
+	}
+}
+
+func TestRenderHTMLIncidentFirstShowsPeakTableTxnBeforeTheme(t *testing.T) {
+	out, err := RenderHTML(productHTMLFixture())
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+
+	verdictIdx := strings.Index(out, `id="incident-verdict"`)
+	peakIdx := strings.Index(out, `id="peak-minute"`)
+	tableIdx := strings.Index(out, `id="hottest-table"`)
+	txnIdx := strings.Index(out, `id="largest-txn"`)
+	themeIdx := strings.Index(out, `class="theme-switcher"`)
+	tpsIdx := strings.Index(out, `id="chart-tps"`)
+	if verdictIdx < 0 || peakIdx < 0 || tableIdx < 0 || txnIdx < 0 || themeIdx < 0 || tpsIdx < 0 {
+		t.Fatalf("expected incident markers in HTML")
+	}
+	if !(verdictIdx < peakIdx && peakIdx < tableIdx && tableIdx < txnIdx && txnIdx < themeIdx && txnIdx < tpsIdx) {
+		t.Fatalf("expected verdict/peak/table/txn before theme switcher and TPS chart, got verdict=%d peak=%d table=%d txn=%d theme=%d tps=%d",
+			verdictIdx, peakIdx, tableIdx, txnIdx, themeIdx, tpsIdx)
+	}
+	for _, token := range []string{
+		"shop.orders · 8,000",
+		"mysql-bin.000044:12345-23456",
+		"UPDATE shop.orders SET status",
+		"vs window median",
+	} {
+		if !strings.Contains(out, token) {
+			t.Fatalf("expected incident token %q", token)
+		}
+	}
+}
+
+func TestRenderHTMLEmptyFindingsDoesNotClaimHealthy(t *testing.T) {
+	out, err := RenderHTML(model.AnalysisResult{})
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+	if strings.Contains(out, "workload looks healthy") || strings.Contains(out, "负载看起来健康") {
+		t.Fatalf("empty HTML report still claims the workload is healthy\n%s", out)
+	}
+	if !strings.Contains(out, "No high-signal findings detected.") {
+		t.Fatalf("expected shared no-findings copy, got HTML without it")
+	}
+}
+
+func TestRenderHTMLUsesAlertSpikeBaselineWhenPresent(t *testing.T) {
+	result := productTextFixture()
+	peak := result.Diagnostics.HotIntervals[0].Minute
+	result.Alerts = []model.Alert{{
+		Type:     "spike",
+		Severity: "warning",
+		Minute:   peak,
+		Message:  "Write spike detected",
+		Details: map[string]any{
+			"rows":     9000,
+			"baseline": 1200,
+			"factor":   7.5,
+		},
+	}}
+
+	out, err := RenderHTML(result)
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+	if !strings.Contains(out, "vs spike baseline") || !strings.Contains(out, "1,200") {
+		t.Fatalf("expected analyzer spike baseline to be surfaced\n%s", out)
+	}
+}
+
+func TestCollectDisplayFindingsRespectsTopN(t *testing.T) {
+	result := productTextFixture()
+	got := collectDisplayFindings(result, 1)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(got))
+	}
+	if got[0].Severity != "critical" {
+		t.Fatalf("expected critical spike first, got %+v", got[0])
+	}
+}

--- a/internal/report/findings_test.go
+++ b/internal/report/findings_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"binlogviz/internal/model"
 )
@@ -141,6 +142,62 @@ func TestRenderHTMLUsesAlertSpikeBaselineWhenPresent(t *testing.T) {
 	}
 	if !strings.Contains(out, "vs spike baseline") || !strings.Contains(out, "1,200") {
 		t.Fatalf("expected analyzer spike baseline to be surfaced\n%s", out)
+	}
+}
+
+func TestRenderHTMLScreenshotLikeTinyEmptyAlertsIsNotHealthy(t *testing.T) {
+	// Mirrors the v0.21.0 / live MariaDB first screens: tiny window, empty alerts.
+	start := time.Date(2026, 3, 15, 14, 10, 26, 0, time.UTC)
+	result := model.AnalysisResult{
+		Summary: model.WorkloadSummary{
+			TotalTransactions: 4,
+			TotalRows:         5,
+			TotalEvents:       16,
+			StartTime:         start,
+			EndTime:           start,
+		},
+		Tables: []model.TableStats{{
+			Schema: "shop", Table: "orders", TotalRows: 5, InsertRows: 3, UpdateRows: 2, TxnCount: 4,
+		}},
+		Diagnostics: model.Diagnostics{
+			HotIntervals: []model.MinuteBucket{{
+				Minute: start, TotalRows: 5, TxnCount: 4,
+				TableRows: map[string]int{"shop.orders": 5},
+			}},
+			LargestTransactions: []model.Transaction{{
+				TxnKey:          "txn-1",
+				TotalRows:       2,
+				BinlogPathStart: "mysql-bin.000123",
+				PositionStart:   240,
+				PositionEnd:     480,
+			}},
+		},
+	}
+
+	textOut, err := RenderText(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	htmlOut, err := RenderHTML(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(textOut, "[critical] Write spike at 2026-03-15 14:10: rows=5, txns=4") {
+		t.Fatalf("expected text critical spike\n%s", textOut)
+	}
+	if strings.Contains(htmlOut, "workload looks healthy") {
+		t.Fatal("screenshot-like tiny report still shows the old healthy first screen")
+	}
+	if !strings.Contains(htmlOut, "Write spike at 2026-03-15 14:10: rows=5, txns=4") {
+		t.Fatalf("HTML verdict missing the text spike\n%s", htmlOut)
+	}
+	for _, token := range []string{`id="incident-verdict"`, `id="peak-minute"`, `id="hottest-table"`, `id="largest-txn"`, "shop.orders"} {
+		if !strings.Contains(htmlOut, token) {
+			t.Fatalf("expected first-screen token %q", token)
+		}
+	}
+	if strings.Index(htmlOut, `id="incident-verdict"`) > strings.Index(htmlOut, `class="theme-switcher"`) {
+		t.Fatal("theme switcher still precedes the incident verdict")
 	}
 }
 

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -189,6 +189,7 @@ type htmlTxnDiagnostic struct {
 	BinlogBytes  int
 	Tables       []htmlTxnTable
 	Location     string
+	LocationNote string
 	QuerySummary string
 	Inserts      int
 	Updates      int
@@ -506,11 +507,10 @@ func buildHTMLData(result model.AnalysisResult, opts Options, echartsJS string) 
 
 	if len(d.Tables) > 0 {
 		d.HottestTable = d.Tables[0]
-		d.HottestTable.QuerySummary = sampleQueryForTable(result, d.HottestTable.Key)
 		d.HasHottestTable = true
 	}
 
-	if location := firstSuspiciousLocation(result); location != "" {
+	if location := firstUsableRollbackLocation(result); location != "" {
 		d.RollbackHint = location
 		d.HasRollbackHint = true
 	}
@@ -585,7 +585,8 @@ func buildHTMLTxnDiagnostic(txn model.Transaction, mode SQLContextMode) htmlTxnD
 		Duration:     txn.Duration.String(),
 		BinlogBytes:  int(txn.BinlogBytes),
 		Tables:       sortedTxnTables(txn.Tables),
-		Location:     formatBinlogSpan(txn),
+		Location:     formatRecordedTxnLocation(txn),
+		LocationNote: xidOnlyLocationNote(txn),
 		QuerySummary: transactionTextQuery(txn, mode),
 		Inserts:      inserts,
 		Updates:      updates,
@@ -640,15 +641,6 @@ func sortedHotTables(tableRows map[string]int) []htmlHotTable {
 		items = items[:8]
 	}
 	return items
-}
-
-func sampleQueryForTable(result model.AnalysisResult, tableKey string) string {
-	for _, pattern := range result.Patterns {
-		if _, ok := pattern.Tables[tableKey]; ok && strings.TrimSpace(pattern.SampleQuerySummary) != "" {
-			return pattern.SampleQuerySummary
-		}
-	}
-	return ""
 }
 
 func spikeBaselineFromAlerts(alerts []model.Alert, peak time.Time) (int, float64, bool) {
@@ -735,10 +727,6 @@ func sortedTxnTables(tables map[string]int) []htmlTxnTable {
 		return items[i].Rows > items[j].Rows
 	})
 	return items
-}
-
-func formatBinlogSpan(txn model.Transaction) string {
-	return formatBinlogLocationWithEnd(txn.BinlogPathStart, txn.PositionStart, txn.BinlogPathEnd, txn.PositionEnd)
 }
 
 func formatBinlogLocation(path string, start, end int64) string {

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1,6 +1,6 @@
 // Package report renders self-contained HTML reports from bounded analysis results.
 // input: analyzer-produced AnalysisResult values plus optional SQL context presentation controls.
-// output: single self-contained HTML file with embedded ECharts, dark OLED theme, inline CSS.
+// output: single self-contained HTML incident page with demoted charts and shared findings.
 // pos: HTML renderer for the CLI output path after analyzer Finalize.
 // note: if this file changes, update this header and module README.md.
 package report
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"binlogviz/internal/i18n"
 	"binlogviz/internal/model"
 )
 
@@ -97,6 +98,15 @@ type htmlReportData struct {
 	Alerts              []htmlAlert
 	HasAlerts           bool
 	TopAlerts           []htmlAlert
+	Verdict             htmlAlert
+	PeakMinute          htmlHotInterval
+	HasPeakMinute       bool
+	HottestTable        htmlTableRow
+	HasHottestTable     bool
+	IncidentTxn         htmlTxnDiagnostic
+	HasIncidentTxn      bool
+	RollbackHint        string
+	HasRollbackHint     bool
 	Drilldowns          []htmlDrilldown
 	HasDrilldowns       bool
 	MinuteLabels        template.JS
@@ -139,22 +149,23 @@ type htmlRepTxn struct {
 }
 
 type htmlTableRow struct {
-	Key         string
-	DOMID       string
-	Schema      string
-	Table       string
-	Total       int
-	Inserts     int
-	Updates     int
-	Deletes     int
-	Txns        int
-	DDLCount    int
-	EventCount  int
-	InsertPct   string
-	UpdatePct   string
-	DeletePct   string
-	DDLPct      string
-	HasActivity bool
+	Key          string
+	DOMID        string
+	Schema       string
+	Table        string
+	Total        int
+	Inserts      int
+	Updates      int
+	Deletes      int
+	Txns         int
+	DDLCount     int
+	EventCount   int
+	InsertPct    string
+	UpdatePct    string
+	DeletePct    string
+	DDLPct       string
+	HasActivity  bool
+	QuerySummary string
 }
 
 type htmlAlert struct {
@@ -180,6 +191,10 @@ type htmlTxnDiagnostic struct {
 	Tables       []htmlTxnTable
 	Location     string
 	QuerySummary string
+	Inserts      int
+	Updates      int
+	Deletes      int
+	HasOps       bool
 }
 
 type htmlTxnTable struct {
@@ -188,12 +203,22 @@ type htmlTxnTable struct {
 }
 
 type htmlHotInterval struct {
-	Timestamp   string
-	Rows        int
-	Txns        int
-	Events      int
-	BinlogBytes int
-	DDLCount    int
+	Timestamp      string
+	Rows           int
+	Txns           int
+	Events         int
+	BinlogBytes    int
+	DDLCount       int
+	Tables         []htmlHotTable
+	BaselineRows   int
+	BaselineFactor float64
+	HasBaseline    bool
+	BaselineLabel  string
+}
+
+type htmlHotTable struct {
+	Key  string
+	Rows int
 }
 
 type htmlFileCoverageData struct {
@@ -276,23 +301,25 @@ func buildHTMLData(result model.AnalysisResult, opts Options, echartsJS string) 
 	}
 	d.TableActivitySeries = mustJSON(tableActivitySeries)
 
-	// Alerts
-	for _, a := range result.Alerts {
-		badge := "INFO"
-		switch a.Severity {
-		case "warning":
-			badge = "WARN"
-		case "critical":
-			badge = "CRIT"
-		}
+	// Findings: same list the text report prints. Never treat empty alerts as healthy.
+	findings := collectDisplayFindings(result, opts.TopN)
+	for _, finding := range findings {
 		d.Alerts = append(d.Alerts, htmlAlert{
-			Severity: a.Severity,
-			Message:  a.Message,
-			Badge:    badge,
+			Severity: finding.Severity,
+			Message:  finding.Message,
+			Badge:    findingBadge(finding.Severity),
 		})
 	}
 	d.HasAlerts = len(d.Alerts) > 0
-	// Top 4 alerts for executive summary display.
+	if len(findings) > 0 {
+		d.Verdict = d.Alerts[0]
+	} else {
+		d.Verdict = htmlAlert{
+			Severity: "info",
+			Message:  i18n.T("report.text.noFindings"),
+			Badge:    "INFO",
+		}
+	}
 	topLimit := len(d.Alerts)
 	if topLimit > 4 {
 		topLimit = 4
@@ -316,30 +343,32 @@ func buildHTMLData(result model.AnalysisResult, opts Options, echartsJS string) 
 	d.DDLCount = len(d.DDLEvents)
 
 	for _, txn := range limitTransactions(result.Diagnostics.LargestTransactions, 1) {
-		d.LargestTransactions = append(d.LargestTransactions, buildHTMLTxnDiagnostic(txn))
+		d.LargestTransactions = append(d.LargestTransactions, buildHTMLTxnDiagnostic(txn, opts.SQLContextMode))
 	}
 	d.HasLargestTxns = len(d.LargestTransactions) > 0
+	if d.HasLargestTxns {
+		d.IncidentTxn = d.LargestTransactions[0]
+		d.HasIncidentTxn = true
+	}
 
 	for _, txn := range limitTransactions(result.Diagnostics.LongestTransactions, 1) {
-		d.LongestTransactions = append(d.LongestTransactions, buildHTMLTxnDiagnostic(txn))
+		d.LongestTransactions = append(d.LongestTransactions, buildHTMLTxnDiagnostic(txn, opts.SQLContextMode))
 	}
 	d.HasLongestTxns = len(d.LongestTransactions) > 0
 
-	for _, interval := range result.Diagnostics.HotIntervals {
-		d.HotIntervals = append(d.HotIntervals, htmlHotInterval{
-			Timestamp:   interval.Minute.Format("2006-01-02 15:04:05"),
-			Rows:        interval.TotalRows,
-			Txns:        interval.TxnCount,
-			Events:      interval.EventCount,
-			BinlogBytes: int(interval.BinlogBytes),
-			DDLCount:    interval.DDLCount,
-		})
+	for i, interval := range result.Diagnostics.HotIntervals {
+		item := buildHTMLHotInterval(interval, result.Minutes, result.Alerts)
+		d.HotIntervals = append(d.HotIntervals, item)
+		if i == 0 {
+			d.PeakMinute = item
+			d.HasPeakMinute = true
+		}
 	}
 	d.HasHotIntervals = len(d.HotIntervals) > 0
 
 	// Widest transactions
 	for _, txn := range limitTransactions(result.Diagnostics.WidestTransactions, 1) {
-		d.WidestTransactions = append(d.WidestTransactions, buildHTMLTxnDiagnostic(txn))
+		d.WidestTransactions = append(d.WidestTransactions, buildHTMLTxnDiagnostic(txn, opts.SQLContextMode))
 	}
 	d.HasWidestTxns = len(d.WidestTransactions) > 0
 
@@ -481,6 +510,17 @@ func buildHTMLData(result model.AnalysisResult, opts Options, echartsJS string) 
 	}
 	d.HasDrilldowns = len(d.Drilldowns) > 0
 
+	if len(d.Tables) > 0 {
+		d.HottestTable = d.Tables[0]
+		d.HottestTable.QuerySummary = sampleQueryForTable(result, d.HottestTable.Key)
+		d.HasHottestTable = true
+	}
+
+	if location := firstSuspiciousLocation(result); location != "" {
+		d.RollbackHint = location
+		d.HasRollbackHint = true
+	}
+
 	return d
 }
 
@@ -540,7 +580,10 @@ func formatFileSize(bytes int64) string {
 	}
 }
 
-func buildHTMLTxnDiagnostic(txn model.Transaction) htmlTxnDiagnostic {
+func buildHTMLTxnDiagnostic(txn model.Transaction, mode SQLContextMode) htmlTxnDiagnostic {
+	inserts := txn.Operations["INSERT"]
+	updates := txn.Operations["UPDATE"]
+	deletes := txn.Operations["DELETE"]
 	return htmlTxnDiagnostic{
 		TxnKey:       txn.TxnKey,
 		Rows:         txn.TotalRows,
@@ -549,7 +592,137 @@ func buildHTMLTxnDiagnostic(txn model.Transaction) htmlTxnDiagnostic {
 		BinlogBytes:  int(txn.BinlogBytes),
 		Tables:       sortedTxnTables(txn.Tables),
 		Location:     formatBinlogSpan(txn),
-		QuerySummary: txn.QuerySummary,
+		QuerySummary: transactionTextQuery(txn, mode),
+		Inserts:      inserts,
+		Updates:      updates,
+		Deletes:      deletes,
+		HasOps:       inserts+updates+deletes > 0,
+	}
+}
+
+func buildHTMLHotInterval(interval model.MinuteBucket, minutes []model.MinuteBucket, alerts []model.Alert) htmlHotInterval {
+	item := htmlHotInterval{
+		Timestamp:   interval.Minute.Format("2006-01-02 15:04:05"),
+		Rows:        interval.TotalRows,
+		Txns:        interval.TxnCount,
+		Events:      interval.EventCount,
+		BinlogBytes: int(interval.BinlogBytes),
+		DDLCount:    interval.DDLCount,
+		Tables:      sortedHotTables(interval.TableRows),
+	}
+	if baseline, factor, ok := spikeBaselineFromAlerts(alerts, interval.Minute); ok {
+		item.BaselineRows = baseline
+		item.BaselineFactor = factor
+		item.HasBaseline = true
+		item.BaselineLabel = "alert"
+		return item
+	}
+	if baseline, ok := windowRowMedian(minutes, interval.Minute); ok {
+		item.BaselineRows = baseline
+		item.HasBaseline = true
+		item.BaselineLabel = "window"
+		if baseline > 0 {
+			item.BaselineFactor = float64(interval.TotalRows) / float64(baseline)
+		}
+	}
+	return item
+}
+
+func sortedHotTables(tableRows map[string]int) []htmlHotTable {
+	if len(tableRows) == 0 {
+		return nil
+	}
+	items := make([]htmlHotTable, 0, len(tableRows))
+	for key, rows := range tableRows {
+		items = append(items, htmlHotTable{Key: key, Rows: rows})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Rows == items[j].Rows {
+			return items[i].Key < items[j].Key
+		}
+		return items[i].Rows > items[j].Rows
+	})
+	if len(items) > 8 {
+		items = items[:8]
+	}
+	return items
+}
+
+func sampleQueryForTable(result model.AnalysisResult, tableKey string) string {
+	for _, pattern := range result.Patterns {
+		if _, ok := pattern.Tables[tableKey]; ok && strings.TrimSpace(pattern.SampleQuerySummary) != "" {
+			return pattern.SampleQuerySummary
+		}
+	}
+	return ""
+}
+
+func spikeBaselineFromAlerts(alerts []model.Alert, peak time.Time) (int, float64, bool) {
+	peakMinute := peak.Truncate(time.Minute)
+	for _, alert := range alerts {
+		if alert.Type != "spike" || alert.Details == nil {
+			continue
+		}
+		if _, hasTable := alert.Details["table"]; hasTable {
+			continue
+		}
+		if !alert.Minute.IsZero() && alert.Minute.Truncate(time.Minute) != peakMinute {
+			continue
+		}
+		baseline, okBaseline := intFromAny(alert.Details["baseline"])
+		factor, okFactor := floatFromAny(alert.Details["factor"])
+		if okBaseline && okFactor {
+			return baseline, factor, true
+		}
+	}
+	return 0, 0, false
+}
+
+func windowRowMedian(minutes []model.MinuteBucket, peak time.Time) (int, bool) {
+	peakMinute := peak.Truncate(time.Minute)
+	values := make([]int, 0, len(minutes))
+	for _, minute := range minutes {
+		if minute.Minute.Truncate(time.Minute) == peakMinute {
+			continue
+		}
+		values = append(values, minute.TotalRows)
+	}
+	if len(values) == 0 {
+		return 0, false
+	}
+	sort.Ints(values)
+	n := len(values)
+	if n%2 == 1 {
+		return values[n/2], true
+	}
+	return (values[n/2-1] + values[n/2]) / 2, true
+}
+
+func intFromAny(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func floatFromAny(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
 	}
 }
 

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -97,7 +97,6 @@ type htmlReportData struct {
 	TPSValues           template.JS
 	Alerts              []htmlAlert
 	HasAlerts           bool
-	TopAlerts           []htmlAlert
 	Verdict             htmlAlert
 	PeakMinute          htmlHotInterval
 	HasPeakMinute       bool
@@ -320,11 +319,6 @@ func buildHTMLData(result model.AnalysisResult, opts Options, echartsJS string) 
 			Badge:    "INFO",
 		}
 	}
-	topLimit := len(d.Alerts)
-	if topLimit > 4 {
-		topLimit = 4
-	}
-	d.TopAlerts = d.Alerts[:topLimit]
 
 	for _, ddl := range result.Diagnostics.DDLEvents {
 		object := strings.Trim(strings.TrimSpace(ddl.Schema+"."+ddl.Table), ".")

--- a/internal/report/html_chart_test.go
+++ b/internal/report/html_chart_test.go
@@ -1,0 +1,70 @@
+// Package report verifies analyze HTML activity charts stay visible on short series.
+// input: a one-minute Duration-0s AnalysisResult like the v0.21.0 fixture first screen.
+// output: TPS and rows-per-minute series use a visible mark when a polyline cannot be drawn.
+// pos: regression coverage for the empty single-point ECharts line (symbol: none).
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"binlogviz/internal/model"
+)
+
+func TestRenderHTMLSingleMinuteChartsStayVisible(t *testing.T) {
+	start := time.Date(2026, 3, 15, 14, 10, 26, 0, time.UTC)
+	result := model.AnalysisResult{
+		Summary: model.WorkloadSummary{
+			TotalTransactions: 4,
+			TotalRows:         5,
+			TotalEvents:       16,
+			StartTime:         start,
+			EndTime:           start,
+			Duration:          0,
+		},
+		Minutes: []model.MinuteBucket{{
+			Minute:    start,
+			TotalRows: 5,
+			TxnCount:  4,
+		}},
+		Timeseries: model.Timeseries{
+			TPSSeries:  []model.TimeseriesPoint{{Minute: start, Value: 0.0666666667}},
+			RowsSeries: []model.TimeseriesPoint{{Minute: start, Value: 5}},
+		},
+	}
+
+	out, err := RenderHTML(result)
+	if err != nil {
+		t.Fatalf("RenderHTML() error: %v", err)
+	}
+
+	if !strings.Contains(out, `"14:10"`) {
+		t.Fatal("expected the single minute to remain on the x-axis")
+	}
+	if !strings.Contains(out, "function visibleLineMark") {
+		t.Fatal("expected a short-series visible-mark helper")
+	}
+	if !strings.Contains(out, "visibleLineMark(tpsValues)") {
+		t.Fatal("expected TPS/min to use the visible-mark helper")
+	}
+	if !strings.Contains(out, "visibleLineMark(minuteRows)") {
+		t.Fatal("expected rows-per-minute to use the visible-mark helper")
+	}
+	if !strings.Contains(out, `symbol: sparse ? 'circle' : 'none'`) {
+		t.Fatal("expected a line+circle mark when a series has fewer than 2 points")
+	}
+	if !strings.Contains(out, "symbolSize: sparse ? 10 : 0") {
+		t.Fatal("expected a symbol size of at least 8 for a single-point series")
+	}
+
+	// The 1-minute series must not be hardcoded to an invisible polyline.
+	tpsBlock := out[strings.Index(out, "visibleLineMark(tpsValues)"):]
+	if i := strings.Index(tpsBlock, "visibleLineMark(minuteRows)"); i > 0 {
+		tpsBlock = tpsBlock[:i]
+	}
+	if strings.Contains(tpsBlock, "symbol: 'none'") {
+		t.Fatal("TPS series must not force symbol: none for a single-minute report")
+	}
+}

--- a/internal/report/html_drilldown_test.go
+++ b/internal/report/html_drilldown_test.go
@@ -549,10 +549,6 @@ func TestAnalyzeHTMLUsesReportTopNForTopTables(t *testing.T) {
 
 func TestAnalyzeHTMLSummarySectionHasKeyFindingsArea(t *testing.T) {
 	result := productHTMLFixture()
-	result.Alerts = []model.Alert{
-		{Severity: "warning", Message: "high row volume detected"},
-		{Severity: "critical", Message: "long-running transaction found"},
-	}
 
 	out, err := RenderHTML(result)
 	if err != nil {
@@ -564,13 +560,13 @@ func TestAnalyzeHTMLSummarySectionHasKeyFindingsArea(t *testing.T) {
 	if summaryIdx < 0 || findingsIdx < 0 {
 		t.Fatal("expected summary and findings sections")
 	}
-	// Key findings must appear inside the summary section, before the standalone findings section.
-	keyFindingsIdx := strings.Index(out, "key-findings")
-	if keyFindingsIdx < 0 {
-		t.Fatal("expected key-findings area in summary section")
+	// The one-line verdict is the first-screen findings surface, before the list below.
+	verdictIdx := strings.Index(out, `id="incident-verdict"`)
+	if verdictIdx < 0 {
+		t.Fatal("expected incident verdict in summary section")
 	}
-	if keyFindingsIdx > findingsIdx {
-		t.Fatal("expected key-findings inside summary, before standalone findings section")
+	if verdictIdx > findingsIdx {
+		t.Fatal("expected incident verdict inside summary, before standalone findings section")
 	}
 }
 

--- a/internal/report/html_drilldown_test.go
+++ b/internal/report/html_drilldown_test.go
@@ -51,6 +51,12 @@ func productHTMLFixture() model.AnalysisResult {
 		Rows:        500,
 		Events:      75,
 	}}
+	result.Diagnostics.HotIntervals = []model.MinuteBucket{{
+		Minute:    start.Add(time.Minute),
+		TotalRows: 9000,
+		TxnCount:  100,
+		TableRows: map[string]int{"shop.orders": 8000, "shop.users": 1000},
+	}}
 	result.Diagnostics.LargestTransactions = []model.Transaction{{
 		TxnKey:          "txn-largest",
 		TotalRows:       12000,
@@ -58,8 +64,10 @@ func productHTMLFixture() model.AnalysisResult {
 		BinlogBytes:     20480,
 		EventCount:      80,
 		Tables:          map[string]int{"shop.orders": 11000, "shop.order_items": 1000},
+		Operations:      map[string]int{"UPDATE": 11000, "INSERT": 1000},
 		QuerySummary:    "UPDATE shop.orders SET status = 'paid' WHERE id BETWEEN ? AND ?",
 		BinlogPathStart: "mysql-bin.000044",
+		BinlogPathEnd:   "mysql-bin.000044",
 		PositionStart:   12345,
 		PositionEnd:     23456,
 	}}
@@ -419,13 +427,13 @@ func TestAnalyzeHTMLUsesDBAReadingPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Five-section reading path: Summary → Findings → Activity → Objects → Evidence.
+	// Incident-first reading path: Summary → Findings → Objects → Evidence → Charts.
 	expectedOrder := []string{
 		`id="executive-summary"`,
 		`id="section-findings"`,
-		`id="section-activity"`,
 		`id="section-objects"`,
 		`id="section-evidence"`,
+		`id="section-activity"`,
 	}
 	last := -1
 	for _, token := range expectedOrder {
@@ -568,10 +576,12 @@ func TestAnalyzeHTMLSummarySectionHasKeyFindingsArea(t *testing.T) {
 
 func TestAnalyzeHTMLFindingsSectionShowsAlertsWithSeverity(t *testing.T) {
 	result := model.AnalysisResult{
-		Alerts: []model.Alert{
-			{Severity: "critical", Message: "critical issue"},
-			{Severity: "warning", Message: "warning issue"},
-			{Severity: "info", Message: "info notice"},
+		Diagnostics: model.Diagnostics{
+			Findings: []model.Finding{
+				{Severity: "critical", Message: "critical issue"},
+				{Severity: "warning", Message: "warning issue"},
+				{Severity: "info", Message: "info notice"},
+			},
 		},
 	}
 
@@ -598,14 +608,13 @@ func TestAnalyzeHTMLActivitySectionContainsChartsInOrder(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Activity section must contain charts in logical reading order: total activity → composition → anomaly peaks.
+	// Demoted activity section still keeps the existing chart IDs.
 	activityIdx := strings.Index(out, `id="section-activity"`)
-	objectsIdx := strings.Index(out, `id="section-objects"`)
-	if activityIdx < 0 || objectsIdx < 0 {
-		t.Fatal("expected section-activity and section-objects")
+	if activityIdx < 0 {
+		t.Fatal("expected section-activity")
 	}
 
-	activitySection := out[activityIdx:objectsIdx]
+	activitySection := out[activityIdx:]
 
 	for _, token := range []string{
 		`id="chart-tps"`,

--- a/internal/report/html_template.go
+++ b/internal/report/html_template.go
@@ -1097,6 +1097,17 @@ const htmlReportTemplate = `<!DOCTYPE html>
     return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   }
 
+  function visibleLineMark(data) {
+    var sparse = !data || data.length < 2;
+    return {
+      type: 'line',
+      data: data,
+      symbol: sparse ? 'circle' : 'none',
+      symbolSize: sparse ? 10 : 0,
+      showSymbol: sparse
+    };
+  }
+
   function makeTheme() {
     return {
       backgroundColor: 'transparent',
@@ -1150,14 +1161,11 @@ const htmlReportTemplate = `<!DOCTYPE html>
         splitLine: { lineStyle: { color: border, type: 'dashed' } }
       },
       tooltip: { ...t.tooltip, trigger: 'axis' },
-      series: [{
+      series: [Object.assign(visibleLineMark(tpsValues), {
         name: '{{t "report.html.analyze.avgTPSPerMinute"}}',
-        type: 'line',
-        data: tpsValues,
         smooth: 0.25,
-        symbol: 'none',
         lineStyle: { color: accent, width: 2 }
-      }]
+      })]
     });
 
     c1 = echarts.init(document.getElementById('chart-timeline'), null, {renderer: 'svg'});
@@ -1178,16 +1186,13 @@ const htmlReportTemplate = `<!DOCTYPE html>
         splitLine: { lineStyle: { color: border, type: 'dashed' } }
       },
       tooltip: { ...t.tooltip, trigger: 'axis' },
-      series: [{
+      series: [Object.assign(visibleLineMark(minuteRows), {
         name: '{{t "report.html.common.rows"}}',
-        type: 'line',
-        data: minuteRows,
         smooth: 0.3,
-        symbol: 'none',
         lineStyle: { color: primary, width: 2 },
         areaStyle: { color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
           colorStops: [{offset: 0, color: primary + '4d'}, {offset: 1, color: primary + '00'}] } }
-      }]
+      })]
     });
 
     c2 = echarts.init(document.getElementById('chart-tables'), null, {renderer: 'svg'});

--- a/internal/report/html_template.go
+++ b/internal/report/html_template.go
@@ -245,6 +245,74 @@ const htmlReportTemplate = `<!DOCTYPE html>
   .key-finding-badge.warning  { background: rgba(251,191,36,0.15); color: var(--warn); }
   .key-finding-badge.info     { background: rgba(37,99,235,0.15); color: var(--primary); }
 
+  .verdict {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--surface2);
+    margin-bottom: 14px;
+  }
+  .verdict.critical { border-left: 4px solid var(--danger); }
+  .verdict.warning  { border-left: 4px solid var(--warn); }
+  .verdict.info     { border-left: 4px solid var(--primary); }
+  .verdict-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    color: var(--muted);
+    margin-bottom: 4px;
+  }
+  .verdict-text { font-size: 15px; font-weight: 600; color: var(--text); line-height: 1.45; }
+  .incident-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px 20px;
+    padding: 0 2px 14px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .incident-meta strong { color: var(--text); font-family: 'Fira Code', monospace; font-weight: 600; }
+  .incident-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+  .incident-card {
+    padding: 14px 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface2);
+  }
+  .incident-card.peak { border-color: var(--danger); }
+  .incident-card-wide { grid-column: 1 / -1; }
+  .peak-tables { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+  .peak-table-btn {
+    font-family: 'Fira Code', monospace;
+    font-size: 11px;
+    padding: 4px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--primary);
+    cursor: pointer;
+  }
+  .peak-table-btn:hover { border-color: var(--primary); }
+  tbody tr.table-summary-row.is-filtered { outline: 1px solid var(--accent); background: var(--surface2); }
+  .mono { font-family: 'Fira Code', monospace; }
+  .footer-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 32px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+
   /* Section */
   .section {
     background: var(--surface);
@@ -536,8 +604,10 @@ const htmlReportTemplate = `<!DOCTYPE html>
   }
   @media (max-width: 600px) {
     .cards { grid-template-columns: 1fr 1fr; }
+    .incident-grid { grid-template-columns: 1fr; }
     .header { flex-direction: column; gap: 12px; text-align: center; }
     .header-meta { text-align: center; }
+    .footer-row { flex-direction: column; }
   }
 </style>
 </head>
@@ -547,55 +617,83 @@ const htmlReportTemplate = `<!DOCTYPE html>
   <!-- Header -->
   <div class="header">
     <div class="header-logo">Binlog<span>Viz</span></div>
-    <div style="display:flex;align-items:center;gap:20px;">
-      <div class="header-meta">
-        <strong>{{t "report.html.analyze.header"}}</strong>
-        {{t "report.html.common.generatedAt"}}: {{.GeneratedAt}}
-      </div>
-      <div class="theme-switcher">
-        <button class="theme-btn" data-t="nebula" title="Nebula"></button>
-        <button class="theme-btn" data-t="forest" title="Forest"></button>
-        <button class="theme-btn" data-t="navy"   title="Navy"></button>
-        <button class="theme-btn" data-t="ember"  title="Ember"></button>
-        <button class="theme-btn" data-t="light"  title="Light"></button>
-      </div>
+    <div class="header-meta">
+      <strong>{{t "report.html.analyze.header"}}</strong>
+      {{t "report.html.common.generatedAt"}}: {{.GeneratedAt}}
     </div>
   </div>
 
-  <!-- ═══ Section 1: Executive Summary ═══ -->
+  <!-- ═══ Section 1: Incident ═══ -->
   <section class="section" id="executive-summary">
     <div class="section-header"><span class="dot"></span>{{t "report.html.analyze.executiveSummary"}}</div>
     <div class="section-body" style="padding:16px">
-      <div class="cards" style="margin-bottom:0">
-        <div class="card">
-          <div class="card-label">{{t "report.html.common.transactions"}}</div>
-          <div class="card-value">{{.TotalTxns}}</div>
+      <div class="verdict {{.Verdict.Severity}}" id="incident-verdict">
+        <span class="key-finding-badge {{.Verdict.Severity}}">{{.Verdict.Badge}}</span>
+        <div>
+          <div class="verdict-label">{{t "report.html.analyze.verdict"}}</div>
+          <div class="verdict-text">{{.Verdict.Message}}</div>
         </div>
-        <div class="card accent">
-          <div class="card-label">{{t "report.html.common.affectedRows"}}</div>
-          <div class="card-value">{{.TotalRows}}</div>
-        </div>
-        <div class="card success">
-          <div class="card-label">{{t "report.html.common.events"}}</div>
-          <div class="card-value">{{.TotalEvents}}</div>
-        </div>
+      </div>
+      <div class="incident-meta">
+        <span>{{t "report.html.common.affectedRows"}}: <strong>{{fmtIntHTML .TotalRows}}</strong></span>
+        <span>{{t "report.html.common.transactions"}}: <strong>{{fmtIntHTML .TotalTxns}}</strong></span>
+        <span>{{t "report.html.common.events"}}: <strong>{{fmtIntHTML .TotalEvents}}</strong></span>
         {{if .StartTime}}
-        <div class="card warn">
-          <div class="card-label">{{t "report.html.common.timeRange"}}</div>
-          <div class="card-value" style="font-size:13px;margin-top:4px">{{.StartTime}}</div>
-          <div class="card-sub">→ {{.EndTime}}</div>
-          <div class="card-sub">{{t "report.html.common.duration"}}: {{.Duration}}</div>
-        </div>
-        {{else}}
-        <div class="card">
-          <div class="card-label">{{t "report.html.common.timeRange"}}</div>
-          <div class="card-value" style="font-size:16px;color:var(--muted)">{{t "report.html.common.notAvailable"}}</div>
+        <span>{{t "report.html.common.timeRange"}}: <strong>{{.StartTime}}</strong> → {{.EndTime}} ({{.Duration}})</span>
+        {{end}}
+        {{if .HasDDLEvents}}<span>{{t "report.html.analyze.ddlCount"}}: <strong>{{.DDLCount}}</strong></span>{{end}}
+        {{if .HasRollbackHint}}<span>{{t "report.text.firstSuspiciousPosition"}}: <strong class="mono">{{.RollbackHint}}</strong></span>{{end}}
+      </div>
+      <div class="incident-grid">
+        {{if .HasPeakMinute}}
+        <div class="incident-card peak incident-card-wide" id="peak-minute">
+          <div class="diagnostic-title">{{t "report.html.analyze.peakMinute"}}</div>
+          <div class="diagnostic-head" style="margin-top:8px">
+            <div class="diagnostic-title">{{.PeakMinute.Timestamp}}</div>
+            <div class="diagnostic-meta">{{t "report.html.common.rows"}}={{fmtIntHTML .PeakMinute.Rows}} · {{t "report.html.common.txns"}}={{fmtIntHTML .PeakMinute.Txns}}</div>
+          </div>
+          {{if .PeakMinute.HasBaseline}}
+          <div class="diagnostic-body">
+            {{if eq .PeakMinute.BaselineLabel "alert"}}{{t "report.html.analyze.vsSpikeBaseline"}}{{else}}{{t "report.html.analyze.vsWindowMedian"}}{{end}}:
+            <span class="mono">{{fmtIntHTML .PeakMinute.BaselineRows}}</span>
+            {{if .PeakMinute.BaselineFactor}} · {{t "report.html.analyze.factor"}} {{printf "%.1f" .PeakMinute.BaselineFactor}}×{{end}}
+          </div>
+          {{end}}
+          {{if .PeakMinute.Tables}}
+          <div class="key-findings-title" style="margin-top:10px">{{t "report.html.analyze.tablesInPeakMinute"}}</div>
+          <div class="peak-tables">
+            {{range .PeakMinute.Tables}}
+            <button type="button" class="peak-table-btn" data-filter-table="{{.Key}}">{{.Key}} · {{fmtIntHTML .Rows}}</button>
+            {{end}}
+          </div>
+          {{end}}
         </div>
         {{end}}
-        {{if .HasDDLEvents}}
-        <div class="card danger">
-          <div class="card-label">{{t "report.html.analyze.ddlCount"}}</div>
-          <div class="card-value">{{.DDLCount}}</div>
+        {{if .HasHottestTable}}
+        <div class="incident-card" id="hottest-table">
+          <div class="diagnostic-title">{{t "report.html.analyze.hottestTable"}}</div>
+          <div class="diagnostic-head" style="margin-top:8px">
+            <button type="button" class="peak-table-btn" data-filter-table="{{.HottestTable.Key}}">{{.HottestTable.Key}}</button>
+            <div class="diagnostic-meta">{{t "report.html.common.rows"}}={{fmtIntHTML .HottestTable.Total}} · {{t "report.html.common.txns"}}={{fmtIntHTML .HottestTable.Txns}}</div>
+          </div>
+          <div class="diagnostic-body">
+            <div><span class="op-ins">I {{.HottestTable.InsertPct}}</span> · <span class="op-upd">U {{.HottestTable.UpdatePct}}</span> · <span class="op-del">D {{.HottestTable.DeletePct}}</span></div>
+            {{if .HottestTable.QuerySummary}}<div>{{t "report.html.analyze.querySummary"}}: <span class="mono">{{.HottestTable.QuerySummary}}</span></div>{{end}}
+          </div>
+        </div>
+        {{end}}
+        {{if .HasIncidentTxn}}
+        <div class="incident-card" id="largest-txn">
+          <div class="diagnostic-title">{{t "report.html.analyze.largestTransactionsByRows"}}</div>
+          <div class="diagnostic-head" style="margin-top:8px">
+            <div class="diagnostic-title">{{.IncidentTxn.TxnKey}}</div>
+            <div class="diagnostic-meta">{{t "report.html.common.rows"}}={{fmtIntHTML .IncidentTxn.Rows}}</div>
+          </div>
+          <div class="diagnostic-body">
+            {{if .IncidentTxn.Location}}<div>{{t "report.html.analyze.binlogSpan"}}: <span class="mono">{{.IncidentTxn.Location}}</span></div>{{end}}
+            {{if .IncidentTxn.HasOps}}<div><span class="op-ins">I {{fmtIntHTML .IncidentTxn.Inserts}}</span> · <span class="op-upd">U {{fmtIntHTML .IncidentTxn.Updates}}</span> · <span class="op-del">D {{fmtIntHTML .IncidentTxn.Deletes}}</span></div>{{end}}
+            {{if .IncidentTxn.QuerySummary}}<div>{{t "report.html.analyze.querySummary"}}: <span class="mono">{{.IncidentTxn.QuerySummary}}</span></div>{{end}}
+          </div>
         </div>
         {{end}}
       </div>
@@ -628,55 +726,13 @@ const htmlReportTemplate = `<!DOCTYPE html>
       </div>
       {{else}}
       <div class="no-alerts">
-        <span class="no-alerts-icon">✓</span>
-        <span>{{t "report.html.analyze.noAlerts"}}</span>
+        <span>{{t "report.text.noFindings"}}</span>
       </div>
       {{end}}
     </div>
   </section>
 
-  <!-- ═══ Section 3: Activity Overview ═══ -->
-  <section class="section" id="section-activity">
-    <div class="section-header"><span class="dot" style="background:var(--accent)"></span>{{t "report.html.analyze.sectionActivity"}}</div>
-    <div class="section-body">
-      <div class="section-desc">{{t "report.html.analyze.activityCharts"}}</div>
-      <div class="charts-grid">
-        <div class="chart-panel chart-panel-large">
-          <div class="chart-title">{{t "report.html.analyze.avgTPSPerMinute"}}</div>
-          <div class="chart-box chart-large" id="chart-tps"></div>
-        </div>
-        <div class="chart-panel chart-panel-wide">
-          <div class="chart-title">{{t "report.html.analyze.rowsPerMinute"}}</div>
-          <div class="chart-box" id="chart-timeline"></div>
-        </div>
-        <div class="chart-panel">
-          <div class="chart-title">{{t "report.html.common.operationMix"}}</div>
-          <div class="chart-box" id="chart-ops"></div>
-        </div>
-        {{if .HasHotIntervals}}
-        <div class="chart-panel">
-          <div class="chart-title">{{t "report.html.analyze.hotIntervals"}}</div>
-          <div class="diagnostic-list" style="padding:0">
-            {{range .HotIntervals}}
-            <div class="diagnostic-item">
-              <div class="diagnostic-head">
-                <div class="diagnostic-title">{{.Timestamp}}</div>
-                <div class="diagnostic-meta">{{t "report.html.common.rows"}}={{fmtIntHTML .Rows}} · {{t "report.html.common.txns"}}={{fmtIntHTML .Txns}} · {{t "report.html.common.events"}}={{fmtIntHTML .Events}}</div>
-              </div>
-              <div class="diagnostic-body">
-                <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
-                {{if .DDLCount}}<div>{{t "report.html.analyze.ddlEvents"}}: {{fmtIntHTML .DDLCount}}</div>{{end}}
-              </div>
-            </div>
-            {{end}}
-          </div>
-        </div>
-        {{end}}
-      </div>
-    </div>
-  </section>
-
-  <!-- ═══ Section 4: Hot Objects ═══ -->
+  <!-- ═══ Section 3: Hot Objects ═══ -->
   <section class="section" id="section-objects">
     <div class="section-header"><span class="dot" style="background:var(--accent)"></span>{{t "report.html.analyze.sectionObjects"}}</div>
     <div class="section-body">
@@ -975,7 +1031,57 @@ const htmlReportTemplate = `<!DOCTYPE html>
     </div>
   </section><!-- /section-evidence -->
 
-  <div class="footer">{{t "report.html.common.generatedBy"}} &middot; {{.GeneratedAt}}</div>
+  <!-- ═══ Demoted charts ═══ -->
+  <section class="section" id="section-activity">
+    <div class="section-header"><span class="dot" style="background:var(--accent)"></span>{{t "report.html.analyze.sectionActivity"}}</div>
+    <div class="section-body">
+      <div class="section-desc">{{t "report.html.analyze.activityCharts"}}</div>
+      <div class="charts-grid">
+        <div class="chart-panel chart-panel-wide">
+          <div class="chart-title">{{t "report.html.analyze.rowsPerMinute"}}</div>
+          <div class="chart-box" id="chart-timeline"></div>
+        </div>
+        <div class="chart-panel">
+          <div class="chart-title">{{t "report.html.analyze.avgTPSPerMinute"}}</div>
+          <div class="chart-box" id="chart-tps"></div>
+        </div>
+        <div class="chart-panel">
+          <div class="chart-title">{{t "report.html.common.operationMix"}}</div>
+          <div class="chart-box" id="chart-ops"></div>
+        </div>
+        {{if .HasHotIntervals}}
+        <div class="chart-panel">
+          <div class="chart-title">{{t "report.html.analyze.hotIntervals"}}</div>
+          <div class="diagnostic-list" style="padding:0">
+            {{range .HotIntervals}}
+            <div class="diagnostic-item">
+              <div class="diagnostic-head">
+                <div class="diagnostic-title">{{.Timestamp}}</div>
+                <div class="diagnostic-meta">{{t "report.html.common.rows"}}={{fmtIntHTML .Rows}} · {{t "report.html.common.txns"}}={{fmtIntHTML .Txns}} · {{t "report.html.common.events"}}={{fmtIntHTML .Events}}</div>
+              </div>
+              <div class="diagnostic-body">
+                <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
+                {{if .DDLCount}}<div>{{t "report.html.analyze.ddlEvents"}}: {{fmtIntHTML .DDLCount}}</div>{{end}}
+              </div>
+            </div>
+            {{end}}
+          </div>
+        </div>
+        {{end}}
+      </div>
+    </div>
+  </section>
+
+  <div class="footer footer-row">
+    <div>{{t "report.html.common.generatedBy"}} &middot; {{.GeneratedAt}}</div>
+    <div class="theme-switcher" title="{{t "report.html.analyze.theme"}}">
+      <button class="theme-btn" data-t="nebula" title="Nebula"></button>
+      <button class="theme-btn" data-t="forest" title="Forest"></button>
+      <button class="theme-btn" data-t="navy"   title="Navy"></button>
+      <button class="theme-btn" data-t="ember"  title="Ember"></button>
+      <button class="theme-btn" data-t="light"  title="Light"></button>
+    </div>
+  </div>
 </div>
 
 <script>{{.EChartsJS}}</script>
@@ -1030,7 +1136,9 @@ const htmlReportTemplate = `<!DOCTYPE html>
     if (c2) c2.dispose();
     if (c3) c3.dispose();
 
-    c0 = echarts.init(document.getElementById('chart-tps'), null, {renderer: 'svg'});
+    var tpsEl = document.getElementById('chart-tps');
+    if (!tpsEl) { return; }
+    c0 = echarts.init(tpsEl, null, {renderer: 'svg'});
     c0.setOption({
       ...t,
       legend: { top: 0, textStyle: { color: muted, fontSize: 10 } },
@@ -1228,24 +1336,45 @@ const htmlReportTemplate = `<!DOCTYPE html>
     btn.addEventListener('click', function() { setTheme(btn.getAttribute('data-t')); });
   });
 
+  function openTable(tableKey) {
+    var row = document.querySelector('tr.table-summary-row[data-table-key="' + tableKey + '"]');
+    if (!row) {
+      return;
+    }
+    document.querySelectorAll('tr.table-summary-row').forEach(function(other) {
+      other.classList.toggle('is-filtered', other.getAttribute('data-table-key') === tableKey);
+    });
+    row.scrollIntoView({block: 'center'});
+    var domID = row.getAttribute('data-table-dom-id');
+    var detail = document.querySelector('tr.table-detail-row[data-table-key="' + tableKey + '"]');
+    if (!detail) {
+      return;
+    }
+    document.querySelectorAll('tr.table-detail-row').forEach(function(other) {
+      other.setAttribute('hidden', '');
+    });
+    detail.removeAttribute('hidden');
+    if (domID) {
+      renderTableCharts(tableKey, domID);
+    }
+  }
+
   document.querySelectorAll('tr.table-summary-row.has-activity').forEach(function(row) {
     row.addEventListener('click', function() {
       var tableKey = row.getAttribute('data-table-key');
-      var domID = row.getAttribute('data-table-dom-id');
       var detail = document.querySelector('tr.table-detail-row[data-table-key="' + tableKey + '"]');
-      if (!detail) {
-        return;
-      }
-      var isHidden = detail.hasAttribute('hidden');
-      document.querySelectorAll('tr.table-detail-row').forEach(function(other) {
-        other.setAttribute('hidden', '');
-      });
-      if (!isHidden) {
+      if (detail && !detail.hasAttribute('hidden') && row.classList.contains('is-filtered')) {
         detail.setAttribute('hidden', '');
+        row.classList.remove('is-filtered');
         return;
       }
-      detail.removeAttribute('hidden');
-      renderTableCharts(tableKey, domID);
+      openTable(tableKey);
+    });
+  });
+
+  document.querySelectorAll('[data-filter-table]').forEach(function(el) {
+    el.addEventListener('click', function() {
+      openTable(el.getAttribute('data-filter-table'));
     });
   });
 

--- a/internal/report/html_template.go
+++ b/internal/report/html_template.go
@@ -691,6 +691,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
           </div>
           <div class="diagnostic-body">
             {{if .IncidentTxn.Location}}<div>{{t "report.html.analyze.binlogSpan"}}: <span class="mono">{{.IncidentTxn.Location}}</span></div>{{end}}
+            {{if .IncidentTxn.LocationNote}}<div class="diagnostic-meta">{{.IncidentTxn.LocationNote}}</div>{{end}}
             {{if .IncidentTxn.HasOps}}<div><span class="op-ins">I {{fmtIntHTML .IncidentTxn.Inserts}}</span> · <span class="op-upd">U {{fmtIntHTML .IncidentTxn.Updates}}</span> · <span class="op-del">D {{fmtIntHTML .IncidentTxn.Deletes}}</span></div>{{end}}
             {{if .IncidentTxn.QuerySummary}}<div>{{t "report.html.analyze.querySummary"}}: <span class="mono">{{.IncidentTxn.QuerySummary}}</span></div>{{end}}
           </div>
@@ -806,6 +807,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             </div>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
+              {{if .LocationNote}}<div class="diagnostic-meta">{{.LocationNote}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}
@@ -827,6 +829,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             </div>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
+              {{if .LocationNote}}<div class="diagnostic-meta">{{.LocationNote}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}
@@ -848,6 +851,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             </div>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
+              {{if .LocationNote}}<div class="diagnostic-meta">{{.LocationNote}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}

--- a/internal/report/html_template.go
+++ b/internal/report/html_template.go
@@ -697,17 +697,6 @@ const htmlReportTemplate = `<!DOCTYPE html>
         </div>
         {{end}}
       </div>
-      {{if .HasAlerts}}
-      <div class="key-findings" id="key-findings">
-        <div class="key-findings-title">{{t "report.html.analyze.keyFindings"}}</div>
-        {{range .TopAlerts}}
-        <div class="key-finding-item">
-          <span class="key-finding-badge {{.Severity}}">{{.Badge}}</span>
-          <span>{{.Message}}</span>
-        </div>
-        {{end}}
-      </div>
-      {{end}}
     </div>
   </section>
 

--- a/internal/report/location.go
+++ b/internal/report/location.go
@@ -1,0 +1,81 @@
+// Package report decides when a recorded transaction span is safe to show as a rollback hint.
+// input: analyzer-produced Transaction positions and byte counts, including XID-only spans.
+// output: formatted locations, plus an XID-only signal so HTML never invents file:pos.
+// pos: shared location helper for text next-actions and the HTML incident page.
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"binlogviz/internal/i18n"
+	"binlogviz/internal/model"
+)
+
+// maxXIDOnlySpanBytes is the largest recorded span we treat as a commit XID
+// rather than a usable transaction start. Dogfood #18 records a 31-byte XID.
+const maxXIDOnlySpanBytes = 64
+
+func recordedTxnSpanBytes(txn model.Transaction) int64 {
+	if txn.BinlogBytes > 0 {
+		return txn.BinlogBytes
+	}
+	if txn.PositionStart > 0 && txn.PositionEnd > txn.PositionStart {
+		return txn.PositionEnd - txn.PositionStart
+	}
+	return 0
+}
+
+// isXIDOnlyTxnSpan reports that the analyzer only stored a commit-XID interval.
+// It does not invent a real start position; it only withholds a rollback hint.
+func isXIDOnlyTxnSpan(txn model.Transaction) bool {
+	span := recordedTxnSpanBytes(txn)
+	if span <= 0 || span > maxXIDOnlySpanBytes {
+		return false
+	}
+	return txn.EventCount > 1 || txn.TotalRows > 1
+}
+
+func usableRollbackLocation(txn model.Transaction) string {
+	if isXIDOnlyTxnSpan(txn) {
+		return ""
+	}
+	if txn.BinlogPathStart == "" && txn.PositionStart == 0 && txn.PositionEnd == 0 {
+		return ""
+	}
+	return formatBinlogLocationWithEnd(txn.BinlogPathStart, txn.PositionStart, txn.BinlogPathEnd, txn.PositionEnd)
+}
+
+func xidOnlyLocationNote(txn model.Transaction) string {
+	if !isXIDOnlyTxnSpan(txn) {
+		return ""
+	}
+	return i18n.Tf("report.html.analyze.xidOnlySpan", map[string]any{
+		"Bytes": recordedTxnSpanBytes(txn),
+	})
+}
+
+func firstUsableRollbackLocation(result model.AnalysisResult) string {
+	for _, txn := range [][]model.Transaction{
+		result.Diagnostics.LongestTransactions,
+		result.Diagnostics.LargestTransactions,
+		result.Diagnostics.WidestTransactions,
+	} {
+		if len(txn) == 0 {
+			continue
+		}
+		if loc := usableRollbackLocation(txn[0]); loc != "" {
+			return loc
+		}
+	}
+	if len(result.Diagnostics.DDLEvents) > 0 {
+		ddl := result.Diagnostics.DDLEvents[0]
+		return formatBinlogLocation(ddl.BinlogPath, ddl.PositionStart, ddl.PositionEnd)
+	}
+	return ""
+}
+
+func formatRecordedTxnLocation(txn model.Transaction) string {
+	if txn.BinlogPathStart == "" && txn.PositionStart == 0 && txn.PositionEnd == 0 {
+		return ""
+	}
+	return formatBinlogLocationWithEnd(txn.BinlogPathStart, txn.PositionStart, txn.BinlogPathEnd, txn.PositionEnd)
+}

--- a/internal/report/location_test.go
+++ b/internal/report/location_test.go
@@ -1,0 +1,127 @@
+// Package report verifies XID-only spans are not offered as rollback file:pos.
+// input: transactions that match dogfood issue #18 (31-byte XID) versus usable spans.
+// output: rollback hint omitted for XID-only; recorded span still shown with an honest note.
+// pos: regression coverage so the HTML incident page does not invent start positions.
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"binlogviz/internal/model"
+)
+
+func xidOnlyLargeTxn() model.Transaction {
+	return model.Transaction{
+		TxnKey:          "txn-1",
+		TotalRows:       400000,
+		EventCount:      9524,
+		BinlogBytes:     31,
+		BinlogPathStart: "mysql-bin.000008",
+		BinlogPathEnd:   "mysql-bin.000008",
+		PositionStart:   77914917,
+		PositionEnd:     77914948,
+		Operations:      map[string]int{"INSERT": 400000},
+		Tables:          map[string]int{"dogfood_big.t": 400000},
+	}
+}
+
+func TestIsXIDOnlyTxnSpanMatchesDogfoodLargeTxn(t *testing.T) {
+	txn := xidOnlyLargeTxn()
+	if !isXIDOnlyTxnSpan(txn) {
+		t.Fatal("expected 31-byte / 400000-row span to be treated as XID-only")
+	}
+	if got := usableRollbackLocation(txn); got != "" {
+		t.Fatalf("usable rollback location should be empty, got %q", got)
+	}
+	if formatRecordedTxnLocation(txn) != "mysql-bin.000008:77914917-77914948" {
+		t.Fatalf("recorded span should still be shown, got %q", formatRecordedTxnLocation(txn))
+	}
+}
+
+func TestUsableRollbackLocationKeepsRealSpan(t *testing.T) {
+	txn := model.Transaction{
+		TxnKey:          "txn-real",
+		TotalRows:       2,
+		EventCount:      4,
+		BinlogBytes:     240,
+		BinlogPathStart: "mysql-bin.000123",
+		BinlogPathEnd:   "mysql-bin.000123",
+		PositionStart:   240,
+		PositionEnd:     480,
+	}
+	if isXIDOnlyTxnSpan(txn) {
+		t.Fatal("240-byte span must remain usable")
+	}
+	if got := usableRollbackLocation(txn); got != "mysql-bin.000123:240-480" {
+		t.Fatalf("usable location = %q", got)
+	}
+}
+
+func TestRenderHTMLOmitsXIDOnlyRollbackHint(t *testing.T) {
+	result := model.AnalysisResult{
+		Diagnostics: model.Diagnostics{
+			LargestTransactions: []model.Transaction{xidOnlyLargeTxn()},
+			LongestTransactions: []model.Transaction{xidOnlyLargeTxn()},
+		},
+	}
+
+	textOut, err := RenderText(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	htmlOut, err := RenderHTML(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(textOut, "First suspicious position") {
+		t.Fatalf("text must not offer an XID-only span as a rollback hint\n%s", textOut)
+	}
+	if strings.Contains(htmlOut, "First suspicious position") {
+		t.Fatalf("HTML must not offer an XID-only span as a rollback hint\n%s", htmlOut)
+	}
+	if !strings.Contains(htmlOut, "mysql-bin.000008:77914917-77914948") {
+		t.Fatal("HTML should still show the recorded XID span")
+	}
+	if !strings.Contains(htmlOut, "XID-only") || !strings.Contains(htmlOut, "not a usable --start-position") {
+		t.Fatalf("HTML should say the recorded span is XID-only\n%s", htmlOut)
+	}
+	if strings.Contains(htmlOut, "mysql-bin.000008:385") {
+		t.Fatal("HTML must not invent a start position the analyzer does not have")
+	}
+}
+
+func TestRenderHTMLDrilldownDoesNotLinkRepresentativeTxns(t *testing.T) {
+	result := model.AnalysisResult{
+		PatternDrilldowns: []model.PatternDrilldown{{
+			PatternKey:    "dogfood_big.t|DELETE|large",
+			Label:         "dogfood_big.t / DELETE / large batch",
+			WhySelected:   "high signal: dominates workload",
+			ShareOfRows:   0.02,
+			ShareOfTxns:   0.66,
+			AvgRowsPerTxn: 48.7,
+			RepresentativeTransactions: []model.PatternRepresentativeTxn{
+				{TxnKey: "txn-1", TotalRows: 400000},
+				{TxnKey: "txn-2", TotalRows: 400000},
+			},
+		}},
+		Diagnostics: model.Diagnostics{
+			LargestTransactions: []model.Transaction{xidOnlyLargeTxn()},
+		},
+	}
+
+	out, err := RenderHTML(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "txn-1") {
+		t.Fatal("expected analyzer representative txn to be listed")
+	}
+	for _, token := range []string{`data-filter-txn=`, `href="#txn-1"`, `href="#txn-2"`} {
+		if strings.Contains(out, token) {
+			t.Fatalf("must not add a click path onto representative txns (%s)", token)
+		}
+	}
+}

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -211,7 +211,7 @@ func renderTopTransactions(buf *strings.Builder, result model.AnalysisResult, to
 func renderNextActions(buf *strings.Builder, result model.AnalysisResult) {
 	buf.WriteString("=== " + i18n.T("report.text.nextActions") + " ===\n")
 	buf.WriteString("  " + i18n.T("report.text.openHTML") + "\n")
-	if location := firstSuspiciousLocation(result); location != "" {
+	if location := firstUsableRollbackLocation(result); location != "" {
 		buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.text.firstSuspiciousPosition"), location))
 	}
 	buf.WriteString("\n")
@@ -373,23 +373,6 @@ func downsampleSeries(points []model.TimeseriesPoint, maxBins int) []model.Times
 		}
 	}
 	return result
-}
-
-func firstSuspiciousLocation(result model.AnalysisResult) string {
-	if len(result.Diagnostics.LongestTransactions) > 0 {
-		return formatSuspiciousLocation(result.Diagnostics.LongestTransactions[0])
-	}
-	if len(result.Diagnostics.LargestTransactions) > 0 {
-		return formatSuspiciousLocation(result.Diagnostics.LargestTransactions[0])
-	}
-	if len(result.Diagnostics.WidestTransactions) > 0 {
-		return formatSuspiciousLocation(result.Diagnostics.WidestTransactions[0])
-	}
-	if len(result.Diagnostics.DDLEvents) > 0 {
-		ddl := result.Diagnostics.DDLEvents[0]
-		return formatBinlogLocation(ddl.BinlogPath, ddl.PositionStart, ddl.PositionEnd)
-	}
-	return ""
 }
 
 func formatSuspiciousLocation(txn model.Transaction) string {

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -87,51 +87,13 @@ func formatSparklineResolution(pointCount int) string {
 func renderTopFindings(buf *strings.Builder, result model.AnalysisResult, opts Options) {
 	buf.WriteString("=== " + i18n.T("report.text.topFindings") + " ===\n")
 
-	lines := make([]string, 0, opts.TopN)
-	for _, finding := range result.Diagnostics.Findings {
-		lines = append(lines, fmt.Sprintf("  [%s] %s", finding.Severity, finding.Message))
-		if len(lines) >= opts.TopN {
-			break
-		}
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.HotIntervals) > 0 {
-		hot := result.Diagnostics.HotIntervals[0]
-		lines = append(lines, fmt.Sprintf("  [critical] %s at %s: rows=%d, txns=%d",
-			i18n.T("report.text.writeSpike"), hot.Minute.Format("2006-01-02 15:04"), hot.TotalRows, hot.TxnCount))
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.LongestTransactions) > 0 {
-		txn := result.Diagnostics.LongestTransactions[0]
-		lines = append(lines, fmt.Sprintf("  [warning] %s: %s, rows=%d, tables=%d, file=%s",
-			i18n.T("report.text.longestTransaction"),
-			formatDuration(txn.Duration),
-			txn.TotalRows,
-			len(txn.Tables),
-			formatSuspiciousLocation(txn),
-		))
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.DDLEvents) > 0 {
-		ddl := result.Diagnostics.DDLEvents[0]
-		target := strings.Trim(strings.TrimSpace(ddl.Schema+"."+ddl.Table), ".")
-		if target == "" {
-			target = ddl.Object
-		}
-		lines = append(lines, fmt.Sprintf("  [warning] %s: %s %s at %s",
-			i18n.T("report.text.ddlDetected"),
-			ddl.Operation,
-			target,
-			ddl.Timestamp.Format("2006-01-02 15:04"),
-		))
-	}
-
-	if len(lines) == 0 {
+	findings := collectDisplayFindings(result, opts.TopN)
+	if len(findings) == 0 {
 		buf.WriteString("  " + i18n.T("report.text.noFindings") + "\n\n")
 		return
 	}
-	for _, line := range lines {
-		buf.WriteString(line + "\n")
+	for _, finding := range findings {
+		buf.WriteString(fmt.Sprintf("  [%s] %s\n", finding.Severity, finding.Message))
 	}
 	buf.WriteString("\n")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
HTML from `binlogviz analyze --format html` was a dark dashboard that could say the workload was healthy while the text report printed a `[critical]` write spike. The GitHub README also opened with a long paragraph and snapshot/workflow internals instead of a product first screen.

The v0.21.0 fixture and live MariaDB ROW first screens (theme-picker circles, vanity cards, “✓ No issues detected — workload looks healthy”, then AVG TPS/MIN) are the before. This PR replaces that first screen with an incident header.

Dogfood issues are treated as constraints, not silently papered over:

- **#18** — a recorded 31-byte XID is shown as an XID-only span. It is **not** offered as `First suspicious position` / `--start-position`, and the renderer does **not** invent a real start pos the analyzer does not have.
- **#20** — pattern drilldown representative transactions stay a static list. The incident page does not add a click path onto those keys (which can point at the wrong txn).
- **#19** — prefix listing is out of scope here.

Single-minute chart bug (v0.21.0 fixture: `tpsLabels = ["14:10"]`, Duration 0s): TPS/min and rows-per-minute used `type: 'line'` + `symbol: 'none'`, so one point drew axes and no mark. Those two series now keep a visible circle (size 10) when a series has fewer than 2 points. The x-axis still labels that minute.

## What changed

**HTML incident page**
- Text and HTML now share `collectDisplayFindings` (diagnostics findings, then synthesized write spike / longest txn / first DDL).
- The HTML verdict is that same first finding. An empty `alerts` slice is no longer rendered as “workload looks healthy”.
- First screen is spike-first: verdict, peak minute (with that minute’s tables and peak-vs-baseline), hottest table, largest txn (`file:pos` only when usable, I/U/D, SQL/annotate summary when the analyzer already has them).
- Peak-minute table chips only filter the existing table list. They do not jump to drilldown representative txns.
- Theme switchers moved to the footer; TPS/donut charts sit below objects and evidence.
- Single-minute TPS/min and rows-per-minute charts show a line+circle instead of an empty plot.
- No parser changes and no new analyzer metrics.

**README first screen (EN + ZH, same order)**
- One DBA sentence (what it does to a ROW binlog, including `mysqlbinlog` contrast).
- Verified brew + release-archive one-liners from the current docs (`v0.21.0`).
- Marked placeholders for 3 demo images (no fake screenshots).

**Tests**
- `TestRenderHTMLFindingsParityWithText` — same findings in text and HTML.
- `TestRenderHTMLScreenshotLikeTinyEmptyAlertsIsNotHealthy` — the 4-txn / 5-row / empty-alerts first screen.
- `TestRenderHTMLOmitsXIDOnlyRollbackHint` — dogfood #18 shape (400000 rows, 31-byte XID).
- `TestRenderHTMLDrilldownDoesNotLinkRepresentativeTxns` — no new click path onto #20 keys.
- `TestRenderHTMLSingleMinuteChartsStayVisible` — Duration-0s / one-bucket fixture keeps a visible TPS and rows series.
- `TestAnalyzeCorpusHTMLIncidentFirstScreenMatchesText` — `tps-spike`, `rows-spike`, and `baseline-small` corpora.

## How to check

```bash
go test ./internal/report/ ./internal/i18n/ ./cmd/binlogviz/ -count=1
```

Open a fixture or live HTML report: verdict should match the text Top Findings line; peak minute / hottest table / largest txn should be visible without scrolling past theme pickers. If the analyzer only stored an XID interval, the page must say so and must not invent `file:385-…`. A one-minute report must show a point or bar on TPS/min and rows-per-minute, not empty axes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdd4ec5d-1004-42fb-a809-c29c026dc837?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdd4ec5d-1004-42fb-a809-c29c026dc837&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

