### PR TITLE
fix: text findings, logical UPDATE rows, STATEMENT/MIXED warning

### DIFF
--- a/cmd/binlogviz/analyze.go
+++ b/cmd/binlogviz/analyze.go
@@ -490,8 +490,10 @@ func runAnalysisStreamingWithSnapshotDeps(
 	}
 
 	streamAnalyzer := newAnalyzer(opts, store)
+	var formatObserver binlog.FormatObserver
 
 	handler := func(raw binlog.RawEvent) error {
+		formatObserver.Observe(raw)
 		normalized, err := normalize(raw)
 		if err != nil {
 			return fmt.Errorf("%s", i18n.Tf("error.normalizeError", map[string]any{"Position": raw.Position, "Error": err.Error()}))
@@ -529,23 +531,30 @@ func runAnalysisStreamingWithSnapshotDeps(
 	if hasFileCoverage(fileCoverage) {
 		result.Diagnostics.FileCoverage = fileCoverage
 	}
+	formatErr := noteInputFormat(result, formatObserver)
 
+	var renderErr error
 	switch format {
 	case "json":
 		if snapshotMeta != nil {
 			result.Snapshot = snapshotMeta
 		}
 		if snapshotName != "" {
-			return saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+			renderErr = saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+		} else {
+			renderErr = report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 		}
-		return report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 	case "markdown", "md":
-		return report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
 	case "html":
-		return report.RenderHTMLToStdout(*result, reportOpts)
+		renderErr = report.RenderHTMLToStdout(*result, reportOpts)
 	default:
-		return report.RenderTextToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderTextToStdoutWithOptions(*result, reportOpts)
 	}
+	if renderErr != nil {
+		return renderErr
+	}
+	return formatErr
 }
 
 func runAnalysisStreamingFastWithSnapshot(
@@ -578,8 +587,10 @@ func runAnalysisStreamingFastWithSnapshot(
 	}
 
 	streamAnalyzer := newAnalyzer(opts, store)
+	var formatObserver binlog.FormatObserver
 
 	handler := func(raw binlog.RawEvent) error {
+		formatObserver.Observe(raw)
 		var normalized model.NormalizedEvent
 		ok, err := binlog.NormalizeRawEventInto(raw, &normalized)
 		if err != nil {
@@ -618,27 +629,50 @@ func runAnalysisStreamingFastWithSnapshot(
 	if hasFileCoverage(fileCoverage) {
 		result.Diagnostics.FileCoverage = fileCoverage
 	}
+	formatErr := noteInputFormat(result, formatObserver)
 
+	var renderErr error
 	switch format {
 	case "json":
 		if snapshotMeta != nil {
 			result.Snapshot = snapshotMeta
 		}
 		if snapshotName != "" {
-			return saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+			renderErr = saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+		} else {
+			renderErr = report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 		}
-		return report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 	case "markdown", "md":
-		return report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
 	case "html":
-		return report.RenderHTMLToStdout(*result, reportOpts)
+		renderErr = report.RenderHTMLToStdout(*result, reportOpts)
 	default:
-		return report.RenderTextToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderTextToStdoutWithOptions(*result, reportOpts)
 	}
+	if renderErr != nil {
+		return renderErr
+	}
+	return formatErr
 }
 
 func hasFileCoverage(fileCoverage model.FileCoverage) bool {
 	return len(fileCoverage.Selected) > 0 || len(fileCoverage.Skipped) > 0
+}
+
+func noteInputFormat(result *model.AnalysisResult, observer binlog.FormatObserver) error {
+	if result == nil {
+		return nil
+	}
+	result.Diagnostics.InputFormatGuess = observer.Guess()
+	result.Diagnostics.IgnoredQueryDMLEvents = observer.QueryDMLEvents
+	if observer.QueryDMLEvents == 0 {
+		return nil
+	}
+	_, _ = fmt.Fprintln(os.Stderr, binlog.StatementOrMixedWarning)
+	if observer.RowImageEvents == 0 {
+		return fmt.Errorf("%s", binlog.StatementOrMixedWarning)
+	}
+	return nil
 }
 
 func runAnalysisWithOutput(paths []string, opts analyzer.Options, reportOpts report.Options, format string, snapshotMeta *model.Snapshot, fileCoverage model.FileCoverage, snapshotName, snapshotDir string, dest outputDestination) error {
@@ -683,8 +717,10 @@ func runAnalysisStreamingFastWithOutput(
 	}
 
 	streamAnalyzer := newAnalyzer(opts, store)
+	var formatObserver binlog.FormatObserver
 
 	handler := func(raw binlog.RawEvent) error {
+		formatObserver.Observe(raw)
 		var normalized model.NormalizedEvent
 		ok, err := binlog.NormalizeRawEventInto(raw, &normalized)
 		if err != nil {
@@ -723,18 +759,21 @@ func runAnalysisStreamingFastWithOutput(
 	if hasFileCoverage(fileCoverage) {
 		result.Diagnostics.FileCoverage = fileCoverage
 	}
+	formatErr := noteInputFormat(result, formatObserver)
 
+	var renderErr error
 	switch format {
 	case "json":
 		if snapshotMeta != nil {
 			result.Snapshot = snapshotMeta
 		}
 		if snapshotName != "" {
-			return saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+			renderErr = saveAndWriteJSONReport(*result, reportOpts, snapshotName, snapshotDir)
+		} else {
+			renderErr = report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 		}
-		return report.RenderJSONToStdoutWithOptions(*result, reportOpts)
 	case "markdown", "md":
-		return report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderMarkdownToStdoutWithOptions(*result, reportOpts)
 	case "html":
 		htmlContent, err := report.RenderHTMLWithOptions(*result, reportOpts)
 		if err != nil {
@@ -746,10 +785,13 @@ func runAnalysisStreamingFastWithOutput(
 		if dest.IsFile {
 			printHTMLSaveConfirmation(dest.Path)
 		}
-		return nil
 	default:
-		return report.RenderTextToStdoutWithOptions(*result, reportOpts)
+		renderErr = report.RenderTextToStdoutWithOptions(*result, reportOpts)
 	}
+	if renderErr != nil {
+		return renderErr
+	}
+	return formatErr
 }
 
 func saveAndWriteJSONReport(result model.AnalysisResult, reportOpts report.Options, snapshotName, snapshotDir string) error {

--- a/cmd/binlogviz/integration_test.go
+++ b/cmd/binlogviz/integration_test.go
@@ -1403,9 +1403,9 @@ func TestRealBinlogFixtureEndToEnd(t *testing.T) {
 	if !bytes.Contains([]byte(output), []byte("testdb.users")) {
 		t.Error("expected output to contain testdb.users table")
 	}
-	// Verify we have total row activity in the summary (the fixture has 5 total rows)
-	if !bytes.Contains([]byte(output), []byte("Total Rows: 5")) {
-		t.Error("expected output to contain 'Total Rows: 5'")
+	// Verify we have total row activity in the summary (2 INSERT + 1 UPDATE + 1 DELETE)
+	if !bytes.Contains([]byte(output), []byte("Total Rows: 4")) {
+		t.Error("expected output to contain 'Total Rows: 4'")
 	}
 }
 

--- a/cmd/binlogviz/operator_bugs_test.go
+++ b/cmd/binlogviz/operator_bugs_test.go
@@ -1,0 +1,226 @@
+package binlogviz
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"binlogviz/internal/analyzer"
+	"binlogviz/internal/binlog"
+	"binlogviz/internal/report"
+)
+
+func TestAnalyzeFixtureTextFindingsMatchJSONNoCriticalSpike(t *testing.T) {
+	forceEnglishRuntimeOutput(t)
+	fixture := mustFixturePath(t, "minimal.binlog")
+
+	textOut, _, err := captureStdoutStderrRun(t, func() error {
+		return runAnalysis([]string{fixture}, analyzer.DefaultOptions(), "text")
+	})
+	if err != nil {
+		t.Fatalf("text analyze: %v", err)
+	}
+	if strings.Contains(textOut, "[critical] Write spike") {
+		t.Fatalf("5-row fixture text report invented a critical spike:\n%s", textOut)
+	}
+	if strings.Contains(textOut, "[warning] Longest transaction") {
+		t.Fatalf("0s fixture transaction should not be a warning finding:\n%s", textOut)
+	}
+	if !strings.Contains(textOut, "No high-signal findings detected.") {
+		t.Fatalf("expected text findings to stay empty when JSON has no alerts:\n%s", textOut)
+	}
+
+	jsonOut, _, err := captureStdoutStderrRun(t, func() error {
+		return runAnalysis([]string{fixture}, analyzer.DefaultOptions(), "json")
+	})
+	if err != nil {
+		t.Fatalf("json analyze: %v", err)
+	}
+
+	var decoded struct {
+		Alerts      []any `json:"alerts"`
+		Warnings    int   `json:"warnings"`
+		Diagnostics struct {
+			Findings []any `json:"findings"`
+		} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, jsonOut)
+	}
+	if len(decoded.Alerts) != 0 || decoded.Warnings != 0 || len(decoded.Diagnostics.Findings) != 0 {
+		t.Fatalf("JSON should have empty alerts/findings, got alerts=%d warnings=%d findings=%d",
+			len(decoded.Alerts), decoded.Warnings, len(decoded.Diagnostics.Findings))
+	}
+}
+
+func TestAnalyzeFixtureCountsLogicalUpdateRows(t *testing.T) {
+	forceEnglishRuntimeOutput(t)
+	fixture := mustFixturePath(t, "minimal.binlog")
+
+	out, err := captureStdoutRun(t, func() error {
+		return runAnalysisWithReportOptions([]string{fixture}, analyzer.DefaultOptions(), report.DefaultOptions(), "json")
+	})
+	if err != nil {
+		t.Fatalf("json analyze: %v", err)
+	}
+
+	var decoded struct {
+		Summary struct {
+			TotalRows         int `json:"total_rows"`
+			TotalTransactions int `json:"total_transactions"`
+		} `json:"summary"`
+		Tables []struct {
+			UpdateRows   int `json:"update_rows"`
+			UpdateEvents int `json:"update_events"`
+			InsertRows   int `json:"insert_rows"`
+			DeleteRows   int `json:"delete_rows"`
+			TotalRows    int `json:"total_rows"`
+		} `json:"tables"`
+		Transactions []struct {
+			Operations map[string]int `json:"operations"`
+		} `json:"transactions"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, out)
+	}
+	if decoded.Summary.TotalRows != 4 {
+		t.Fatalf("total_rows=%d, want 4 logical rows", decoded.Summary.TotalRows)
+	}
+	if decoded.Summary.TotalTransactions != 4 {
+		t.Fatalf("total_transactions=%d, want 4", decoded.Summary.TotalTransactions)
+	}
+	if len(decoded.Tables) != 1 {
+		t.Fatalf("tables=%d, want 1", len(decoded.Tables))
+	}
+	table := decoded.Tables[0]
+	if table.InsertRows != 2 || table.UpdateRows != 1 || table.DeleteRows != 1 || table.TotalRows != 4 {
+		t.Fatalf("table I/U/D/total = %d/%d/%d/%d, want 2/1/1/4", table.InsertRows, table.UpdateRows, table.DeleteRows, table.TotalRows)
+	}
+	if table.UpdateEvents != 1 {
+		t.Fatalf("update_events=%d, want 1", table.UpdateEvents)
+	}
+
+	var updateOps int
+	for _, txn := range decoded.Transactions {
+		updateOps += txn.Operations["UPDATE"]
+	}
+	if updateOps != 1 {
+		t.Fatalf("transaction operations.UPDATE sum=%d, want 1", updateOps)
+	}
+}
+
+func TestAnalyzeStatementBinlogWarnsAndExitsNonZero(t *testing.T) {
+	forceEnglishRuntimeOutput(t)
+	now := time.Date(2026, 8, 18, 10, 0, 0, 0, time.UTC)
+	parser := &mockParser{
+		events: []binlog.RawEvent{
+			{Timestamp: now, EventType: "QUERY_EVENT", Query: "INSERT INTO dogfood.users VALUES (1)"},
+			{Timestamp: now.Add(time.Second), EventType: "QUERY_EVENT", Query: "UPDATE dogfood.users SET name='x'"},
+			{Timestamp: now.Add(2 * time.Second), EventType: "QUERY_EVENT", Query: "DELETE FROM dogfood.users WHERE id=1"},
+			{Timestamp: now.Add(3 * time.Second), EventType: "QUERY_EVENT", Query: "INSERT INTO dogfood.users VALUES (2)"},
+			{Timestamp: now.Add(4 * time.Second), EventType: "QUERY_EVENT", Query: "UPDATE dogfood.users SET name='y'"},
+		},
+	}
+
+	stdout, stderr, err := captureStdoutStderrRun(t, func() error {
+		return runAnalysisWithParser([]string{"dummy.binlog"}, analyzer.DefaultOptions(), "text", parser)
+	})
+	if err == nil {
+		t.Fatal("expected non-zero exit for STATEMENT binlog with zero row images")
+	}
+	if !strings.Contains(err.Error(), binlog.StatementOrMixedWarning) {
+		t.Fatalf("error=%v, want %q", err, binlog.StatementOrMixedWarning)
+	}
+	if !strings.Contains(stderr, binlog.StatementOrMixedWarning) {
+		t.Fatalf("stderr missing format warning:\n%s", stderr)
+	}
+	if strings.Contains(stdout, "Open HTML") {
+		t.Fatalf("STATEMENT report should not suggest Open HTML as success:\n%s", stdout)
+	}
+
+	jsonOut, jsonErrStderr, jsonErr := captureStdoutStderrRun(t, func() error {
+		return runAnalysisWithParser([]string{"dummy.binlog"}, analyzer.DefaultOptions(), "json", parser)
+	})
+	if jsonErr == nil {
+		t.Fatal("expected non-zero exit for STATEMENT JSON analyze")
+	}
+	if !strings.Contains(jsonErrStderr, binlog.StatementOrMixedWarning) {
+		t.Fatalf("JSON stderr missing format warning:\n%s", jsonErrStderr)
+	}
+	var decoded struct {
+		Summary struct {
+			TotalRows         int `json:"total_rows"`
+			TotalTransactions int `json:"total_transactions"`
+		} `json:"summary"`
+		Diagnostics struct {
+			InputFormatGuess      string `json:"input_format_guess"`
+			IgnoredQueryDMLEvents int    `json:"ignored_query_dml_events"`
+		} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, jsonOut)
+	}
+	if decoded.Diagnostics.InputFormatGuess != binlog.InputFormatStatement {
+		t.Fatalf("input_format_guess=%q, want STATEMENT", decoded.Diagnostics.InputFormatGuess)
+	}
+	if decoded.Diagnostics.IgnoredQueryDMLEvents != 5 {
+		t.Fatalf("ignored_query_dml_events=%d, want 5", decoded.Diagnostics.IgnoredQueryDMLEvents)
+	}
+	if decoded.Summary.TotalRows != 0 || decoded.Summary.TotalTransactions != 0 {
+		t.Fatalf("STATEMENT should not invent ROW workload, got rows=%d txns=%d", decoded.Summary.TotalRows, decoded.Summary.TotalTransactions)
+	}
+}
+
+func TestAnalyzeMixedBinlogWarnsAndRecordsIgnoredQueryDML(t *testing.T) {
+	forceEnglishRuntimeOutput(t)
+	now := time.Date(2026, 8, 18, 10, 0, 0, 0, time.UTC)
+	parser := &mockParser{
+		events: []binlog.RawEvent{
+			{Timestamp: now, EventType: "QUERY_EVENT", Query: "INSERT INTO dogfood.users VALUES (1)"},
+			{Timestamp: now.Add(time.Second), EventType: "QUERY_EVENT", Query: "UPDATE dogfood.users SET name=UUID()"},
+			{Timestamp: now.Add(2 * time.Second), EventType: "UpdateRowsEventV2", Schema: "dogfood", Table: "users", RowCount: 1},
+			{Timestamp: now.Add(3 * time.Second), EventType: "XID_EVENT"},
+		},
+	}
+
+	stdout, stderr, err := captureStdoutStderrRun(t, func() error {
+		return runAnalysisWithParser([]string{"dummy.binlog"}, analyzer.DefaultOptions(), "json", parser)
+	})
+	if err != nil {
+		t.Fatalf("MIXED with row images should exit 0, got %v", err)
+	}
+	if !strings.Contains(stderr, binlog.StatementOrMixedWarning) {
+		t.Fatalf("stderr missing format warning:\n%s", stderr)
+	}
+
+	var decoded struct {
+		Summary struct {
+			TotalRows         int `json:"total_rows"`
+			TotalTransactions int `json:"total_transactions"`
+		} `json:"summary"`
+		Diagnostics struct {
+			InputFormatGuess      string `json:"input_format_guess"`
+			IgnoredQueryDMLEvents int    `json:"ignored_query_dml_events"`
+		} `json:"diagnostics"`
+		Tables []struct {
+			Schema string `json:"schema"`
+			Table  string `json:"table"`
+		} `json:"tables"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v\n%s", err, stdout)
+	}
+	if decoded.Diagnostics.InputFormatGuess != binlog.InputFormatMixed {
+		t.Fatalf("input_format_guess=%q, want MIXED", decoded.Diagnostics.InputFormatGuess)
+	}
+	if decoded.Diagnostics.IgnoredQueryDMLEvents != 2 {
+		t.Fatalf("ignored_query_dml_events=%d, want 2", decoded.Diagnostics.IgnoredQueryDMLEvents)
+	}
+	if decoded.Summary.TotalRows != 1 || decoded.Summary.TotalTransactions != 1 {
+		t.Fatalf("MIXED should count only the ROW subset, got rows=%d txns=%d", decoded.Summary.TotalRows, decoded.Summary.TotalTransactions)
+	}
+	if len(decoded.Tables) != 1 || decoded.Tables[0].Schema+"."+decoded.Tables[0].Table != "dogfood.users" {
+		t.Fatalf("expected dogfood.users from the ROW image, got %#v", decoded.Tables)
+	}
+}

--- a/cmd/binlogviz/streaming_coverage_test.go
+++ b/cmd/binlogviz/streaming_coverage_test.go
@@ -109,8 +109,8 @@ func TestRunAnalysisRealFixtureMultiFileOrderedInput(t *testing.T) {
 	if !strings.Contains(out, `"total_transactions": 8`) {
 		t.Fatalf("expected eight transactions from two ordered files, got: %s", out)
 	}
-	if !strings.Contains(out, `"total_rows": 10`) {
-		t.Fatalf("expected doubled row count from two ordered files, got: %s", out)
+	if !strings.Contains(out, `"total_rows": 8`) {
+		t.Fatalf("expected doubled logical row count from two ordered files, got: %s", out)
 	}
 }
 

--- a/docs/concept/limitations.md
+++ b/docs/concept/limitations.md
@@ -8,6 +8,8 @@ BinlogViz is built around local MySQL `ROW`-format binlog files.
 
 That boundary matters because the analyzer is designed to consume normalized row-oriented events and derive workload statistics from row activity. If your operational question depends on statement-based replay semantics, a different tooling path is more appropriate.
 
+MIXED-format files are undercounted: only ROW images are included, so Query-DML statements without row images are ignored. Do not treat a MIXED or STATEMENT report as a complete write workload. Analyze warns on stderr (`binlog appears STATEMENT or MIXED; only ROW images are counted`) and exits non-zero when the file has zero row images.
+
 In practical terms, use BinlogViz when your input is a local ROW-format binlog sequence and your goal is workload inspection rather than logical replay.
 
 ## Input Scope

--- a/docs/concept/limitations.zh-CN.md
+++ b/docs/concept/limitations.zh-CN.md
@@ -8,6 +8,8 @@ BinlogViz 面向本地 MySQL `ROW` 格式 binlog 文件。
 
 这个边界非常重要，因为分析器的设计前提是消费规范化后的行级事件，并从行级写入活动中推导负载统计。如果你的运维问题依赖 statement-based replay 语义，那么应该选择另一类工具链。
 
+MIXED 文件会少计：只统计 ROW image，没有行镜像的 Query-DML 会被忽略。不要把 MIXED / STATEMENT 报告当成全量写入。分析会在 stderr 警告 `binlog appears STATEMENT or MIXED; only ROW images are counted`；文件完全没有 row image 时以非 0 退出。
+
 换句话说，当你的输入是本地 `ROW` 格式 binlog 序列，并且目标是做负载分析而不是逻辑回放时，BinlogViz 才是合适的工具。
 
 ## 输入范围

--- a/docs/reference/output-format.md
+++ b/docs/reference/output-format.md
@@ -232,7 +232,7 @@ The top-level JSON object always contains these fields:
 | Field | Type | Required | Notes |
 |------|------|----------|------|
 | `total_transactions` | integer | yes | Total analyzed transactions |
-| `total_rows` | integer | yes | Total affected rows |
+| `total_rows` | integer | yes | Total logical affected rows (UPDATE before/after images count as one row) |
 | `total_events` | integer | yes | Total normalized events included in analysis |
 | `start_time` | string | yes | RFC3339 timestamp, or empty string when no timestamp is available |
 | `end_time` | string | yes | RFC3339 timestamp, or empty string when no timestamp is available |
@@ -248,9 +248,12 @@ The top-level JSON object always contains these fields:
 | `table` | string | yes |
 | `total_rows` | integer | yes |
 | `insert_rows` | integer | yes |
-| `update_rows` | integer | yes |
+| `update_rows` | integer | yes | Logical UPDATE rows (before/after images count as one row) |
+| `update_events` | integer | yes | Number of UPDATE row events |
 | `delete_rows` | integer | yes |
 | `txn_count` | integer | yes |
+
+`diagnostics.input_format_guess` is `ROW`, `STATEMENT`, `MIXED`, or empty when there is not enough signal. `diagnostics.ignored_query_dml_events` counts QUERY-event DML that had no corresponding row images.
 
 ### `transactions`
 

--- a/docs/reference/output-format.zh-CN.md
+++ b/docs/reference/output-format.zh-CN.md
@@ -232,7 +232,7 @@ JSON 报告会以稳定、适合脚本处理的 snake_case 字段名暴露最终
 | Field | Type | Required | Notes |
 |------|------|----------|------|
 | `total_transactions` | integer | yes | 总分析事务数 |
-| `total_rows` | integer | yes | 总影响行数 |
+| `total_rows` | integer | yes | 逻辑影响行数（UPDATE before/after image 计 1 行） |
 | `total_events` | integer | yes | 纳入分析的标准化事件总数 |
 | `start_time` | string | yes | RFC3339 时间戳；如果没有可用时间戳则为空字符串 |
 | `end_time` | string | yes | RFC3339 时间戳；如果没有可用时间戳则为空字符串 |
@@ -248,9 +248,12 @@ JSON 报告会以稳定、适合脚本处理的 snake_case 字段名暴露最终
 | `table` | string | yes |
 | `total_rows` | integer | yes |
 | `insert_rows` | integer | yes |
-| `update_rows` | integer | yes |
+| `update_rows` | integer | yes | 逻辑 UPDATE 行（before/after image 计 1 行） |
+| `update_events` | integer | yes | UPDATE 行事件数 |
 | `delete_rows` | integer | yes |
 | `txn_count` | integer | yes |
+
+`diagnostics.input_format_guess` 为 `ROW` / `STATEMENT` / `MIXED`，信号不足时为空。`diagnostics.ignored_query_dml_events` 统计没有对应 row image 的 Query-DML。
 
 ### `transactions`
 

--- a/internal/analyzer/spikes_test.go
+++ b/internal/analyzer/spikes_test.go
@@ -154,6 +154,33 @@ func TestDetectSpikeAlertsIncludesDetails(t *testing.T) {
 	}
 }
 
+func TestDetectSpikeAlertsSingleMinuteNoBaselineIsNotCritical(t *testing.T) {
+	minute := time.Date(2026, time.March, 15, 14, 10, 0, 0, time.UTC)
+	alerts := DetectSpikeAlerts([]model.MinuteBucket{
+		{Minute: minute, TotalRows: 5, TxnCount: 4},
+	}, Options{
+		DetectSpikes: true,
+		SpikeWindow:  5,
+		SpikeFactor:  3.0,
+		SpikeMinRows: 100,
+	})
+	if len(alerts) != 0 {
+		t.Fatalf("single-minute / no-baseline 5-row sample should not spike, got %#v", alerts)
+	}
+
+	alerts = DetectSpikeAlerts([]model.MinuteBucket{
+		{Minute: minute, TotalRows: 1000, TxnCount: 4},
+	}, Options{
+		DetectSpikes: true,
+		SpikeWindow:  5,
+		SpikeFactor:  3.0,
+		SpikeMinRows: 100,
+	})
+	if len(alerts) != 0 {
+		t.Fatalf("single-minute file with no baseline should not be a critical spike, got %#v", alerts)
+	}
+}
+
 func TestDetectSpikeAlertsHandlesInsufficientHistory(t *testing.T) {
 	// Only 1 bucket of history, which is less than SpikeWindow
 	minute := time.Date(2026, time.March, 9, 10, 2, 0, 0, time.UTC)
@@ -196,9 +223,9 @@ func TestDetectSpikeAlertsMultipleSpikes(t *testing.T) {
 		SpikeFactor:  5.0,
 		SpikeMinRows: 50,
 	})
-    if len(alerts) != 2 {
+	if len(alerts) != 2 {
 		t.Fatalf("expected 2 spike alerts, got %d", len(alerts))
-    }
+	}
 }
 
 func TestAnalyzerIntegratesSpikeAlerts(t *testing.T) {
@@ -252,7 +279,7 @@ func TestDetectSpikeAlertsTableLevel(t *testing.T) {
 		},
 		{
 			Minute:    minute,
-			TotalRows: 110, // overall spike: 110/20 = 5.5x
+			TotalRows: 110,                                                  // overall spike: 110/20 = 5.5x
 			TableRows: map[string]int{"shop.orders": 100, "shop.users": 10}, // orders spike: 100/10 = 10x
 		},
 	}
@@ -313,7 +340,7 @@ func TestDetectSpikeAlertsTableLevelNoOverallSpike(t *testing.T) {
 		},
 		{
 			Minute:    minute,
-			TotalRows: 100, // no overall spike
+			TotalRows: 100,                                                 // no overall spike
 			TableRows: map[string]int{"shop.orders": 90, "shop.users": 10}, // orders spike: 90/10 = 9x
 		},
 	}

--- a/internal/analyzer/tables.go
+++ b/internal/analyzer/tables.go
@@ -23,6 +23,7 @@ type tableStats struct {
 	totalRows     int
 	insertRows    int
 	updateRows    int
+	updateEvents  int
 	deleteRows    int
 	eventCount    int
 	binlogBytes   int64
@@ -89,6 +90,7 @@ func (a *TableAggregator) Consume(ev model.NormalizedEvent) {
 			ts.insertRows += ev.RowCount
 		case "UPDATE":
 			ts.updateRows += ev.RowCount
+			ts.updateEvents++
 		case "DELETE":
 			ts.deleteRows += ev.RowCount
 		}
@@ -150,6 +152,7 @@ func (a *TableAggregator) Snapshot() []model.TableStats {
 			TotalRows:     ts.totalRows,
 			InsertRows:    ts.insertRows,
 			UpdateRows:    ts.updateRows,
+			UpdateEvents:  ts.updateEvents,
 			DeleteRows:    ts.deleteRows,
 			TxnCount:      len(ts.txnSet),
 			EventCount:    ts.eventCount,

--- a/internal/analyzer/tables_test.go
+++ b/internal/analyzer/tables_test.go
@@ -40,6 +40,9 @@ func TestTableAggregatorTracksRowsAndOperations(t *testing.T) {
 	if s.UpdateRows != 1 {
 		t.Fatalf("expected 1 update row, got %d", s.UpdateRows)
 	}
+	if s.UpdateEvents != 1 {
+		t.Fatalf("expected 1 update event, got %d", s.UpdateEvents)
+	}
 	// Same transaction touched this table once
 	if s.TxnCount != 1 {
 		t.Fatalf("expected 1 distinct transaction, got %d", s.TxnCount)

--- a/internal/binlog/README.md
+++ b/internal/binlog/README.md
@@ -9,6 +9,7 @@ Binlog parsing, raw event extraction, normalization, and parse-progress contract
 | `types.go` | Defines `RawEvent`, `Parser`, `ParseProgress`, and the optional `ProgressParser` contract used by the command layer. |
 | `parser.go` | Wraps `go-mysql-org/go-mysql/replication`, extracts raw binlog events, reuses `TableID` table names in the rows-event hot path, and emits monotonic per-input progress offsets. |
 | `normalize.go` | Converts parser-emitted `RawEvent` values into stable analyzer-facing normalized events, including a destination-reuse fast path for streaming callers. Uses first-character dispatch to reduce string comparison overhead in the hot normalization path. |
+| `format.go` | Cheap Query-DML vs ROW-image observation used to guess STATEMENT/MIXED/ROW and warn when only row images are counted. |
 | `probe.go` | Scans binlog files for reusable file-level metadata such as size and chronological earliest/latest non-zero event timestamps, with internal parser-injectable helpers for reuse in tests and later planning work. |
 | `*_test.go` | Covers parser construction, helper behavior, normalization semantics, and real-fixture parser benchmarks isolating parse-only, parse+normalize, and parse+progress layers. |
 | `testdata/*` | Real binlog fixtures used by integration and regression tests. |
@@ -20,6 +21,7 @@ Binlog parsing, raw event extraction, normalization, and parse-progress contract
 - `type ParseProgress`
 - `type ProgressParser`
 - `type FileProbe`
+- `type FormatObserver`
 - `func NewParser() Parser`
 - `func NormalizeRawEvent(RawEvent) (*model.NormalizedEvent, error)`
 - `func NormalizeRawEventInto(RawEvent, *model.NormalizedEvent) (bool, error)`

--- a/internal/binlog/format.go
+++ b/internal/binlog/format.go
@@ -1,0 +1,88 @@
+package binlog
+
+import "strings"
+
+// StatementOrMixedWarning is printed on stderr when Query-DML exists without
+// matching row images. The wording is part of the operator-facing contract.
+const StatementOrMixedWarning = "binlog appears STATEMENT or MIXED; only ROW images are counted"
+
+const (
+	InputFormatROW       = "ROW"
+	InputFormatStatement = "STATEMENT"
+	InputFormatMixed     = "MIXED"
+)
+
+// FormatObserver counts Query-DML versus ROW images so analyze can warn
+// when a STATEMENT or MIXED file would otherwise look like a healthy ROW report.
+type FormatObserver struct {
+	QueryDMLEvents int
+	RowImageEvents int
+}
+
+// Observe records one raw parser event.
+func (o *FormatObserver) Observe(raw RawEvent) {
+	if o == nil {
+		return
+	}
+	if isQueryEventType(raw.EventType) && IsQueryDML(raw.Query) {
+		o.QueryDMLEvents++
+		return
+	}
+	if IsRowImageEvent(raw.EventType) {
+		o.RowImageEvents++
+	}
+}
+
+// Guess returns ROW, STATEMENT, MIXED, or empty when there is not enough signal.
+func (o FormatObserver) Guess() string {
+	return GuessInputFormat(o.QueryDMLEvents, o.RowImageEvents)
+}
+
+// GuessInputFormat classifies a file from cheap Query-DML vs row-image counts.
+func GuessInputFormat(queryDML, rowImages int) string {
+	switch {
+	case queryDML > 0 && rowImages == 0:
+		return InputFormatStatement
+	case queryDML > 0 && rowImages > 0:
+		return InputFormatMixed
+	case rowImages > 0:
+		return InputFormatROW
+	default:
+		return ""
+	}
+}
+
+// IsQueryDML reports whether a QUERY_EVENT body is DML rather than BEGIN/COMMIT/DDL.
+func IsQueryDML(query string) bool {
+	sql := strings.TrimSpace(query)
+	if sql == "" {
+		return false
+	}
+	return hasSQLKeywordPrefix(sql, "INSERT") ||
+		hasSQLKeywordPrefix(sql, "UPDATE") ||
+		hasSQLKeywordPrefix(sql, "DELETE") ||
+		hasSQLKeywordPrefix(sql, "REPLACE")
+}
+
+// IsRowImageEvent reports whether the parser event type carries ROW before/after images.
+func IsRowImageEvent(eventType string) bool {
+	et := strings.ToUpper(eventType)
+	return strings.Contains(et, "WRITEROWS") || strings.Contains(et, "WRITE_ROWS") ||
+		strings.Contains(et, "UPDATEROWS") || strings.Contains(et, "UPDATE_ROWS") ||
+		strings.Contains(et, "DELETEROWS") || strings.Contains(et, "DELETE_ROWS")
+}
+
+func isQueryEventType(eventType string) bool {
+	return eventType == "QUERY_EVENT" || eventType == "QueryEvent"
+}
+
+func hasSQLKeywordPrefix(sql, word string) bool {
+	if len(sql) < len(word) || !strings.EqualFold(sql[:len(word)], word) {
+		return false
+	}
+	if len(sql) == len(word) {
+		return true
+	}
+	next := sql[len(word)]
+	return next == ' ' || next == '\t' || next == '\n' || next == '\r' || next == '/' || next == '('
+}

--- a/internal/binlog/format_test.go
+++ b/internal/binlog/format_test.go
@@ -1,0 +1,67 @@
+package binlog
+
+import "testing"
+
+func TestIsQueryDMLDetectsCommonDML(t *testing.T) {
+	for _, query := range []string{
+		"INSERT INTO users VALUES (1)",
+		"update users set name='x'",
+		"DELETE FROM users WHERE id=1",
+		"REPLACE INTO users VALUES (1)",
+		"INSERT(users)",
+	} {
+		if !IsQueryDML(query) {
+			t.Fatalf("expected Query-DML for %q", query)
+		}
+	}
+}
+
+func TestIsQueryDMLIgnoresBeginCommitAndDDL(t *testing.T) {
+	for _, query := range []string{
+		"BEGIN",
+		"COMMIT",
+		"CREATE TABLE users (id INT)",
+		"ALTER TABLE users ADD COLUMN n INT",
+		"",
+	} {
+		if IsQueryDML(query) {
+			t.Fatalf("did not expect Query-DML for %q", query)
+		}
+	}
+}
+
+func TestGuessInputFormat(t *testing.T) {
+	cases := []struct {
+		queryDML, rowImages int
+		want                string
+	}{
+		{0, 3, InputFormatROW},
+		{5, 0, InputFormatStatement},
+		{5, 1, InputFormatMixed},
+		{0, 0, ""},
+	}
+	for _, tc := range cases {
+		if got := GuessInputFormat(tc.queryDML, tc.rowImages); got != tc.want {
+			t.Fatalf("GuessInputFormat(%d,%d)=%q, want %q", tc.queryDML, tc.rowImages, got, tc.want)
+		}
+	}
+}
+
+func TestFormatObserverCountsQueryDMLAndRowImages(t *testing.T) {
+	var observer FormatObserver
+	observer.Observe(RawEvent{EventType: "QueryEvent", Query: "INSERT INTO users VALUES (1)"})
+	observer.Observe(RawEvent{EventType: "QUERY_EVENT", Query: "UPDATE users SET name='x'"})
+	observer.Observe(RawEvent{EventType: "QUERY_EVENT", Query: "BEGIN"})
+	observer.Observe(RawEvent{EventType: "UpdateRowsEventV2", RowCount: 1})
+	observer.Observe(RawEvent{EventType: "RowsQueryEvent", QuerySQL: "UPDATE users SET name='x'"})
+
+	if observer.QueryDMLEvents != 2 {
+		t.Fatalf("QueryDMLEvents=%d, want 2", observer.QueryDMLEvents)
+	}
+	if observer.RowImageEvents != 1 {
+		t.Fatalf("RowImageEvents=%d, want 1", observer.RowImageEvents)
+	}
+	if observer.Guess() != InputFormatMixed {
+		t.Fatalf("guess=%q, want MIXED", observer.Guess())
+	}
+}

--- a/internal/binlog/parser.go
+++ b/internal/binlog/parser.go
@@ -125,12 +125,22 @@ func applyBinlogEventMetadata(raw *RawEvent, eventTypeName string, event any, ta
 		}
 	case *replication.RowsEvent:
 		applyRowsEventTableName(raw, e, tableNames)
-		if strings.Contains(eventTypeName, "UPDATE") {
-			raw.RowCount = len(e.Rows) / 2
-		} else {
-			raw.RowCount = len(e.Rows)
-		}
+		raw.RowCount = logicalRowCount(eventTypeName, len(e.Rows))
 	}
+}
+
+// logicalRowCount converts raw row-image counts into DBA-facing logical rows.
+// UPDATE events store before/after images as consecutive rows.
+func logicalRowCount(eventTypeName string, imageCount int) int {
+	if isUpdateRowsEventName(eventTypeName) {
+		return imageCount / 2
+	}
+	return imageCount
+}
+
+func isUpdateRowsEventName(eventTypeName string) bool {
+	et := strings.ToUpper(eventTypeName)
+	return strings.Contains(et, "UPDATE") && strings.Contains(et, "ROW")
 }
 
 func applyRowsEventTableName(raw *RawEvent, event *replication.RowsEvent, tableNames map[uint64]cachedTableName) {

--- a/internal/binlog/parser_test.go
+++ b/internal/binlog/parser_test.go
@@ -74,7 +74,7 @@ func TestApplyBinlogEventMetadataReusesCachedTableNameForRowsEvents(t *testing.T
 	}
 }
 
-func TestApplyBinlogEventMetadataPreservesParserUpdateRowCountSemantics(t *testing.T) {
+func TestApplyBinlogEventMetadataCountsUpdateLogicalRows(t *testing.T) {
 	var raw RawEvent
 	applyBinlogEventMetadata(&raw, replication.UPDATE_ROWS_EVENTv2.String(), &replication.RowsEvent{
 		Rows: [][]any{
@@ -85,8 +85,22 @@ func TestApplyBinlogEventMetadataPreservesParserUpdateRowCountSemantics(t *testi
 		},
 	}, nil)
 
-	if raw.RowCount != 4 {
-		t.Fatalf("expected parser row count to preserve raw row images, got %d", raw.RowCount)
+	if raw.RowCount != 2 {
+		t.Fatalf("expected parser to count 2 logical UPDATE rows from 4 images, got %d", raw.RowCount)
+	}
+}
+
+func TestApplyBinlogEventMetadataCountsSingleUpdateAsOneRow(t *testing.T) {
+	var raw RawEvent
+	applyBinlogEventMetadata(&raw, "UpdateRowsEventV2", &replication.RowsEvent{
+		Rows: [][]any{
+			{1, "before"},
+			{1, "after"},
+		},
+	}, nil)
+
+	if raw.RowCount != 1 {
+		t.Fatalf("expected single-row UPDATE to count as 1 logical row, got %d", raw.RowCount)
 	}
 }
 

--- a/internal/model/diagnostics.go
+++ b/internal/model/diagnostics.go
@@ -4,14 +4,16 @@ import "time"
 
 // Diagnostics groups DBA-oriented evidence and coverage metadata.
 type Diagnostics struct {
-	FileCoverage        FileCoverage
-	DDLEvents           []DDLEvent
-	LargestTransactions []Transaction
-	LongestTransactions []Transaction
-	WidestTransactions  []Transaction
-	FileSegments        []FileSegment
-	HotIntervals        []MinuteBucket
-	Findings            []Finding
+	FileCoverage          FileCoverage
+	DDLEvents             []DDLEvent
+	LargestTransactions   []Transaction
+	LongestTransactions   []Transaction
+	WidestTransactions    []Transaction
+	FileSegments          []FileSegment
+	HotIntervals          []MinuteBucket
+	Findings              []Finding
+	InputFormatGuess      string
+	IgnoredQueryDMLEvents int
 }
 
 // FileCoverage summarizes which input files were selected or skipped.

--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -26,6 +26,7 @@ type TableStats struct {
 	TotalRows     int
 	InsertRows    int
 	UpdateRows    int
+	UpdateEvents  int
 	DeleteRows    int
 	TxnCount      int
 	EventCount    int

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -39,6 +39,7 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 - `full` only exposes bounded SQL from `QueryContext.SQL`; it never reconstructs or emits unbounded original SQL.
 - `product.go` owns presentation defaults such as `DefaultTopN` so text, HTML, and command flags share one report contract.
 - The default text report is diagnostic-first: summary, top findings, top tables, and next actions. Minute activity and write-shape patterns require explicit detail options.
+- Text Top Findings are the same `diagnostics.findings` / `alerts` as JSON. Hot intervals and longest transactions are evidence only; they are not synthesized into critical/warning findings.
 - The text Top Tables report sizes its table-name column to the widest displayed name; `Affected Rows` covers INSERT/UPDATE/DELETE rows and `Row Share` is that table's portion of all affected rows.
 - Text rendering is intentionally kept on a fast path: it must not build HTML chart data, read embedded ECharts assets, or render pattern drilldowns unless detail options request them.
 - The JSON renderer omits `snapshot` entirely when `AnalysisResult.Snapshot` is nil, preserving legacy analyze JSON shape.

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -71,14 +71,16 @@ type jsonTxnSizeBucket struct {
 }
 
 type jsonDiagnostics struct {
-	FileCoverage        jsonFileCoverage  `json:"file_coverage"`
-	DDLEvents           []jsonDDLEvent    `json:"ddl_events"`
-	LargestTransactions []jsonTransaction `json:"largest_transactions"`
-	LongestTransactions []jsonTransaction `json:"longest_transactions"`
-	WidestTransactions  []jsonTransaction `json:"widest_transactions"`
-	FileSegments        []jsonFileSegment `json:"file_segments"`
-	HotIntervals        []jsonHotInterval `json:"hot_intervals"`
-	Findings            []jsonFinding     `json:"findings"`
+	FileCoverage          jsonFileCoverage  `json:"file_coverage"`
+	DDLEvents             []jsonDDLEvent    `json:"ddl_events"`
+	LargestTransactions   []jsonTransaction `json:"largest_transactions"`
+	LongestTransactions   []jsonTransaction `json:"longest_transactions"`
+	WidestTransactions    []jsonTransaction `json:"widest_transactions"`
+	FileSegments          []jsonFileSegment `json:"file_segments"`
+	HotIntervals          []jsonHotInterval `json:"hot_intervals"`
+	Findings              []jsonFinding     `json:"findings"`
+	InputFormatGuess      string            `json:"input_format_guess"`
+	IgnoredQueryDMLEvents int               `json:"ignored_query_dml_events"`
 }
 
 type jsonFileCoverage struct {
@@ -135,13 +137,14 @@ type jsonFileSegment struct {
 }
 
 type jsonTableStats struct {
-	Schema     string `json:"schema"`
-	Table      string `json:"table"`
-	TotalRows  int    `json:"total_rows"`
-	InsertRows int    `json:"insert_rows"`
-	UpdateRows int    `json:"update_rows"`
-	DeleteRows int    `json:"delete_rows"`
-	TxnCount   int    `json:"txn_count"`
+	Schema       string `json:"schema"`
+	Table        string `json:"table"`
+	TotalRows    int    `json:"total_rows"`
+	InsertRows   int    `json:"insert_rows"`
+	UpdateRows   int    `json:"update_rows"`
+	UpdateEvents int    `json:"update_events"`
+	DeleteRows   int    `json:"delete_rows"`
+	TxnCount     int    `json:"txn_count"`
 }
 
 type jsonTransaction struct {
@@ -362,14 +365,16 @@ func convertTxnSizeBuckets(buckets []model.TxnSizeBucket) []jsonTxnSizeBucket {
 
 func convertDiagnostics(diagnostics model.Diagnostics, mode SQLContextMode) jsonDiagnostics {
 	return jsonDiagnostics{
-		FileCoverage:        convertFileCoverage(diagnostics.FileCoverage),
-		DDLEvents:           convertDDLEvents(diagnostics.DDLEvents),
-		LargestTransactions: convertTransactions(diagnostics.LargestTransactions, mode),
-		LongestTransactions: convertTransactions(diagnostics.LongestTransactions, mode),
-		WidestTransactions:  convertTransactions(diagnostics.WidestTransactions, mode),
-		FileSegments:        convertFileSegments(diagnostics.FileSegments),
-		HotIntervals:        convertHotIntervals(diagnostics.HotIntervals),
-		Findings:            convertFindings(diagnostics.Findings),
+		FileCoverage:          convertFileCoverage(diagnostics.FileCoverage),
+		DDLEvents:             convertDDLEvents(diagnostics.DDLEvents),
+		LargestTransactions:   convertTransactions(diagnostics.LargestTransactions, mode),
+		LongestTransactions:   convertTransactions(diagnostics.LongestTransactions, mode),
+		WidestTransactions:    convertTransactions(diagnostics.WidestTransactions, mode),
+		FileSegments:          convertFileSegments(diagnostics.FileSegments),
+		HotIntervals:          convertHotIntervals(diagnostics.HotIntervals),
+		Findings:              convertFindings(diagnostics.Findings),
+		InputFormatGuess:      diagnostics.InputFormatGuess,
+		IgnoredQueryDMLEvents: diagnostics.IgnoredQueryDMLEvents,
 	}
 }
 
@@ -491,13 +496,14 @@ func convertTables(tables []model.TableStats) []jsonTableStats {
 	result := make([]jsonTableStats, len(tables))
 	for i, t := range tables {
 		result[i] = jsonTableStats{
-			Schema:     t.Schema,
-			Table:      t.Table,
-			TotalRows:  t.TotalRows,
-			InsertRows: t.InsertRows,
-			UpdateRows: t.UpdateRows,
-			DeleteRows: t.DeleteRows,
-			TxnCount:   t.TxnCount,
+			Schema:       t.Schema,
+			Table:        t.Table,
+			TotalRows:    t.TotalRows,
+			InsertRows:   t.InsertRows,
+			UpdateRows:   t.UpdateRows,
+			UpdateEvents: t.UpdateEvents,
+			DeleteRows:   t.DeleteRows,
+			TxnCount:     t.TxnCount,
 		}
 	}
 	return result

--- a/internal/report/json_test.go
+++ b/internal/report/json_test.go
@@ -232,6 +232,45 @@ func TestRenderJSONIncludesTables(t *testing.T) {
 	}
 }
 
+func TestRenderJSONExposesUpdateEventsAndRows(t *testing.T) {
+	result := model.AnalysisResult{
+		Tables: []model.TableStats{{
+			Schema:       "testdb",
+			Table:        "users",
+			TotalRows:    4,
+			InsertRows:   2,
+			UpdateRows:   1,
+			UpdateEvents: 1,
+			DeleteRows:   1,
+		}},
+		Diagnostics: model.Diagnostics{
+			InputFormatGuess:      "STATEMENT",
+			IgnoredQueryDMLEvents: 5,
+		},
+	}
+
+	out, err := RenderJSON(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	parsed := parseJSONMap(t, out)
+	tables := parsed["tables"].([]any)
+	table := tables[0].(map[string]any)
+	if table["update_rows"].(float64) != 1 {
+		t.Fatalf("update_rows=%v, want 1", table["update_rows"])
+	}
+	if table["update_events"].(float64) != 1 {
+		t.Fatalf("update_events=%v, want 1", table["update_events"])
+	}
+	diagnostics := parsed["diagnostics"].(map[string]any)
+	if diagnostics["input_format_guess"] != "STATEMENT" {
+		t.Fatalf("input_format_guess=%v", diagnostics["input_format_guess"])
+	}
+	if diagnostics["ignored_query_dml_events"].(float64) != 5 {
+		t.Fatalf("ignored_query_dml_events=%v", diagnostics["ignored_query_dml_events"])
+	}
+}
+
 func TestRenderJSONIncludesTransactions(t *testing.T) {
 	result := model.AnalysisResult{
 		Transactions: []model.Transaction{

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -87,45 +87,7 @@ func formatSparklineResolution(pointCount int) string {
 func renderTopFindings(buf *strings.Builder, result model.AnalysisResult, opts Options) {
 	buf.WriteString("=== " + i18n.T("report.text.topFindings") + " ===\n")
 
-	lines := make([]string, 0, opts.TopN)
-	for _, finding := range result.Diagnostics.Findings {
-		lines = append(lines, fmt.Sprintf("  [%s] %s", finding.Severity, finding.Message))
-		if len(lines) >= opts.TopN {
-			break
-		}
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.HotIntervals) > 0 {
-		hot := result.Diagnostics.HotIntervals[0]
-		lines = append(lines, fmt.Sprintf("  [critical] %s at %s: rows=%d, txns=%d",
-			i18n.T("report.text.writeSpike"), hot.Minute.Format("2006-01-02 15:04"), hot.TotalRows, hot.TxnCount))
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.LongestTransactions) > 0 {
-		txn := result.Diagnostics.LongestTransactions[0]
-		lines = append(lines, fmt.Sprintf("  [warning] %s: %s, rows=%d, tables=%d, file=%s",
-			i18n.T("report.text.longestTransaction"),
-			formatDuration(txn.Duration),
-			txn.TotalRows,
-			len(txn.Tables),
-			formatSuspiciousLocation(txn),
-		))
-	}
-
-	if len(lines) < opts.TopN && len(result.Diagnostics.DDLEvents) > 0 {
-		ddl := result.Diagnostics.DDLEvents[0]
-		target := strings.Trim(strings.TrimSpace(ddl.Schema+"."+ddl.Table), ".")
-		if target == "" {
-			target = ddl.Object
-		}
-		lines = append(lines, fmt.Sprintf("  [warning] %s: %s %s at %s",
-			i18n.T("report.text.ddlDetected"),
-			ddl.Operation,
-			target,
-			ddl.Timestamp.Format("2006-01-02 15:04"),
-		))
-	}
-
+	lines := collectTopFindingLines(result, opts.TopN)
 	if len(lines) == 0 {
 		buf.WriteString("  " + i18n.T("report.text.noFindings") + "\n\n")
 		return
@@ -134,6 +96,31 @@ func renderTopFindings(buf *strings.Builder, result model.AnalysisResult, opts O
 		buf.WriteString(line + "\n")
 	}
 	buf.WriteString("\n")
+}
+
+// collectTopFindingLines uses the same alerts/findings contract as JSON.
+// Hot intervals, longest transactions, and DDL timelines are evidence, not extra findings.
+func collectTopFindingLines(result model.AnalysisResult, topN int) []string {
+	if topN <= 0 {
+		return nil
+	}
+	lines := make([]string, 0, topN)
+	for _, finding := range result.Diagnostics.Findings {
+		lines = append(lines, fmt.Sprintf("  [%s] %s", finding.Severity, finding.Message))
+		if len(lines) >= topN {
+			return lines
+		}
+	}
+	if len(lines) > 0 {
+		return lines
+	}
+	for _, alert := range result.Alerts {
+		lines = append(lines, fmt.Sprintf("  [%s] %s", alert.Severity, alert.Message))
+		if len(lines) >= topN {
+			break
+		}
+	}
+	return lines
 }
 
 func renderTopTablesTable(buf *strings.Builder, tables []model.TableStats, topN int) {
@@ -248,11 +235,21 @@ func renderTopTransactions(buf *strings.Builder, result model.AnalysisResult, to
 
 func renderNextActions(buf *strings.Builder, result model.AnalysisResult) {
 	buf.WriteString("=== " + i18n.T("report.text.nextActions") + " ===\n")
-	buf.WriteString("  " + i18n.T("report.text.openHTML") + "\n")
+	if shouldSuggestOpenHTML(result) {
+		buf.WriteString("  " + i18n.T("report.text.openHTML") + "\n")
+	}
 	if location := firstSuspiciousLocation(result); location != "" {
 		buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.text.firstSuspiciousPosition"), location))
 	}
 	buf.WriteString("\n")
+}
+
+func shouldSuggestOpenHTML(result model.AnalysisResult) bool {
+	// Zero row images with ignored Query-DML is not a successful ROW analysis.
+	if result.Diagnostics.IgnoredQueryDMLEvents > 0 && result.Summary.TotalRows == 0 {
+		return false
+	}
+	return true
 }
 
 func renderMinuteDetails(buf *strings.Builder, minutes []model.MinuteBucket, topN int) {

--- a/internal/report/text_test.go
+++ b/internal/report/text_test.go
@@ -24,6 +24,62 @@ func sampleTransactionWithQueryContext() model.Transaction {
 	}
 }
 
+func TestRenderTextTopFindingsComeFromAlertsNotHotIntervals(t *testing.T) {
+	result := productTextFixture()
+	result.Alerts = nil
+	result.Diagnostics.Findings = nil
+	result.Diagnostics.HotIntervals = []model.MinuteBucket{{
+		Minute:    time.Date(2026, 3, 15, 14, 10, 0, 0, time.UTC),
+		TotalRows: 5,
+		TxnCount:  4,
+	}}
+	result.Diagnostics.LongestTransactions = []model.Transaction{{
+		TxnKey:    "txn-tiny",
+		TotalRows: 2,
+		Duration:  0,
+		Tables:    map[string]int{"testdb.users": 2},
+	}}
+
+	out, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "[critical] Write spike") {
+		t.Fatalf("text findings synthesized a critical spike from a 5-row hot interval:\n%s", out)
+	}
+	if strings.Contains(out, "[warning] Longest transaction") {
+		t.Fatalf("text findings synthesized a warning from a 0s/2-row transaction:\n%s", out)
+	}
+	if !strings.Contains(out, "No high-signal findings detected.") {
+		t.Fatalf("expected empty alerts/findings to render no findings:\n%s", out)
+	}
+}
+
+func TestRenderTextTopFindingsUseSameAlertsAsJSON(t *testing.T) {
+	result := productTextFixture()
+	result.Diagnostics.Findings = []model.Finding{{
+		Kind:     "spike",
+		Severity: "warning",
+		Message:  "Write spike detected",
+	}}
+	result.Alerts = []model.Alert{{
+		Type:     "spike",
+		Severity: "warning",
+		Message:  "Write spike detected",
+	}}
+
+	out, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "[warning] Write spike detected") {
+		t.Fatalf("expected text findings to use the JSON alert/finding message:\n%s", out)
+	}
+	if strings.Contains(out, "[critical] Write spike") {
+		t.Fatalf("text findings should not invent a critical severity:\n%s", out)
+	}
+}
+
 func TestRenderTextDefaultIsConciseDiagnosticSummary(t *testing.T) {
 	result := productTextFixture()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes operator-reported dogfood bugs from #8, #9, and #15. Does not touch the HTML incident-page work in #17.

## #8 默认文本把 5 行样本标成 `[critical] Write spike`

根因：文本 Top Findings 会从 `HotIntervals` / `LongestTransactions` / `DDLEvents` **合成** finding，而 JSON 只输出 `DetectSpikeAlerts` / `BuildFindingsFromAlerts` 的结果。`--detect-spikes` 默认关，且 `--spike-min-rows 100`；单分钟、无 baseline 本来就不会出 spike alert。

- 文本 Top Findings 只渲染同一套 `diagnostics.findings` / `alerts`
- 单分钟 / 无 baseline / 5 行样本不再标 critical spike
- 0s / 2 行事务不再标 warning
- testdata `minimal.binlog` 的文本与 JSON 一致：`alerts=[]`、`findings=[]`

## #9 单行 UPDATE 被计成 2 rows

根因：parser 想对 UPDATE 做 `len(rows)/2`，但 `strings.Contains(..., "UPDATE")` 匹配不到 go-mysql 的 `UpdateRowsEventV2`，before/after image 被当成两行。

- 默认按逻辑行计数（1 次单行 UPDATE = 1 row）
- fixture：`total_rows=4`（2 INSERT + 1 UPDATE + 1 DELETE），不再是 5
- JSON 表级同时给 `update_rows` 和 `update_events`

## #15 STATEMENT/MIXED 看起来像成功的空/子集报告

文档写明只做 ROW。STATEMENT 全是 Query-DML、无 row image 时以前 exit 0 并建议 Open HTML；MIXED 只吃到 ROW 子集且不提示。

- 发现 Query-DML 时 stderr：`binlog appears STATEMENT or MIXED; only ROW images are counted`
- 零 row image 时 exit != 0，文本不再建议 Open HTML
- JSON：`diagnostics.input_format_guess`、`diagnostics.ignored_query_dml_events`
- Limitations 补了一句：混格文件会少计，不要当全量

## Tests

- `TestAnalyzeFixtureTextFindingsMatchJSONNoCriticalSpike`
- `TestAnalyzeFixtureCountsLogicalUpdateRows`
- `TestAnalyzeStatementBinlogWarnsAndExitsNonZero`
- `TestAnalyzeMixedBinlogWarnsAndRecordsIgnoredQueryDML`
- plus unit coverage for spike baseline, logical UPDATE images, and format guess

```bash
go test ./internal/binlog/ ./internal/analyzer/ ./internal/report/ ./cmd/binlogviz/ -count=1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77907466-b9dd-4ed6-8d1f-9b4508f10fc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77907466-b9dd-4ed6-8d1f-9b4508f10fc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

