### PR TITLE
fix: real txn spans, Query DDL timeline, and mysqlbinlog commands

### DIFF
--- a/internal/analyzer/README.md
+++ b/internal/analyzer/README.md
@@ -6,10 +6,10 @@
 |------|----------------|
 | `analyzer.go` | Public analyzer entrypoint, streaming lifecycle, final result assembly. |
 | `store.go` | DuckDB-backed internal result store with batch flush, reusable batch slices across flushes, pre-sized hot-path buffers, COUNT(*)-preallocated transaction row scans with lazy map hydration, and Finalize-time query assembly. |
-| `transactions.go` | Reconstructs completed transactions from normalized event boundaries. |
+| `transactions.go` | Reconstructs completed transactions from normalized event boundaries. Same-file `binlog_bytes` is `pos_end - pos_start` (first in-txn event through XID). |
 | `tables.go` | Aggregates per-table row and operation totals. |
 | `buckets.go` | Aggregates per-minute workload buckets and per-table minute rows, using a fast minute-truncation helper on the hot path. |
-| `ddl.go` | Extracts DDL timeline metadata and fast-filters non-DDL ROWS_QUERY SQL before full tokenization. |
+| `ddl.go` | Extracts DDL timeline metadata from Query and ROWS_QUERY SQL, including CREATE/ALTER/DROP DATABASE, RENAME, and TRUNCATE. |
 | `alerts.go` | Builds large transaction alerts from completed transactions. |
 | `spikes.go` | Detects overall and table-level spike alerts from minute buckets. |
 | `diagnostics.go` | Builds DBA-oriented findings with alert-referenced-only transaction indexing, bounded top-N transaction/minute rankings, hot intervals, and file throughput segments. Internal helpers are indexed lookups only; legacy linear scans have been removed. |

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -154,6 +154,7 @@ func (a *Analyzer) consume(ev model.NormalizedEvent) error {
 		return err
 	}
 	ev = a.withCurrentTxnKey(ev)
+	ev = enrichDDLEvent(ev)
 
 	// Track event count and time bounds only after transaction state accepted the event.
 	a.eventCount++
@@ -189,6 +190,24 @@ func (a *Analyzer) withCurrentTxnKey(ev model.NormalizedEvent) model.NormalizedE
 	}
 	if txnKey := a.txnBuilder.CurrentTxnKey(); txnKey != "" {
 		ev.TxnKey = txnKey
+	}
+	return ev
+}
+
+func enrichDDLEvent(ev model.NormalizedEvent) model.NormalizedEvent {
+	if ev.EventType != "DDL" && ev.EventType != "QUERY" {
+		return ev
+	}
+	ddl, ok := DDLEventFromNormalizedEvent(ev)
+	if !ok {
+		return ev
+	}
+	ev.EventType = "DDL"
+	if ev.Schema == "" {
+		ev.Schema = ddl.Schema
+	}
+	if ev.Table == "" {
+		ev.Table = ddl.Table
 	}
 	return ev
 }

--- a/internal/analyzer/ddl.go
+++ b/internal/analyzer/ddl.go
@@ -41,7 +41,7 @@ func ParseDDLStatement(sql string) (DDLStatement, bool) {
 
 	normalized := strings.Join(strings.Fields(trimmed), " ")
 	tokens := strings.Fields(normalized)
-	if len(tokens) < 3 {
+	if len(tokens) < 2 {
 		return DDLStatement{}, false
 	}
 
@@ -52,6 +52,9 @@ func ParseDDLStatement(sql string) (DDLStatement, bool) {
 
 	identifier := findDDLIdentifier(tokens[startIndex:])
 	schema, table := splitQualifiedIdentifier(identifier)
+	if object == "database" && schema == "" && table != "" {
+		schema, table = table, ""
+	}
 
 	return DDLStatement{
 		Operation: operation,
@@ -66,7 +69,8 @@ func hasSupportedDDLPrefix(sql string) bool {
 	return hasWordPrefixFold(sql, "ALTER") ||
 		hasWordPrefixFold(sql, "CREATE") ||
 		hasWordPrefixFold(sql, "DROP") ||
-		hasWordPrefixFold(sql, "TRUNCATE")
+		hasWordPrefixFold(sql, "TRUNCATE") ||
+		hasWordPrefixFold(sql, "RENAME")
 }
 
 func hasWordPrefixFold(sql, word string) bool {
@@ -138,11 +142,20 @@ func DDLEventFromNormalizedEvent(ev model.NormalizedEvent) (model.DDLEvent, bool
 		return model.DDLEvent{}, false
 	}
 
+	schema := stmt.Schema
+	if schema == "" {
+		schema = ev.Schema
+	}
+	table := stmt.Table
+	if table == "" && stmt.Object == "table" {
+		table = ev.Table
+	}
+
 	return model.DDLEvent{
 		BinlogPath:    ev.BinlogPath,
 		Timestamp:     ev.Timestamp.UTC(),
-		Schema:        stmt.Schema,
-		Table:         stmt.Table,
+		Schema:        schema,
+		Table:         table,
 		Operation:     stmt.Operation,
 		Object:        stmt.Object,
 		Statement:     stmt.Statement,
@@ -154,17 +167,34 @@ func DDLEventFromNormalizedEvent(ev model.NormalizedEvent) (model.DDLEvent, bool
 
 func classifyDDL(tokens []string) (operation string, object string, identifierIndex int, ok bool) {
 	first := strings.ToUpper(tokens[0])
-	second := strings.ToUpper(tokens[1])
+	second := ""
+	if len(tokens) > 1 {
+		second = strings.ToUpper(tokens[1])
+	}
 
 	switch {
 	case first == "ALTER" && second == "TABLE":
 		return "ALTER TABLE", "table", 2, true
+	case first == "ALTER" && (second == "DATABASE" || second == "SCHEMA"):
+		return "ALTER DATABASE", "database", 2, true
 	case first == "CREATE" && second == "TABLE":
 		return "CREATE TABLE", "table", skipOptionalIfClause(tokens, 2), true
+	case first == "CREATE" && (second == "DATABASE" || second == "SCHEMA"):
+		return "CREATE DATABASE", "database", skipOptionalIfClause(tokens, 2), true
+	case first == "CREATE" && second == "INDEX":
+		return "CREATE INDEX", "index", 2, true
 	case first == "DROP" && second == "TABLE":
 		return "DROP TABLE", "table", skipOptionalIfClause(tokens, 2), true
+	case first == "DROP" && (second == "DATABASE" || second == "SCHEMA"):
+		return "DROP DATABASE", "database", skipOptionalIfClause(tokens, 2), true
+	case first == "DROP" && second == "INDEX":
+		return "DROP INDEX", "index", 2, true
 	case first == "TRUNCATE" && second == "TABLE":
 		return "TRUNCATE TABLE", "table", 2, true
+	case first == "TRUNCATE":
+		return "TRUNCATE TABLE", "table", 1, true
+	case first == "RENAME" && second == "TABLE":
+		return "RENAME TABLE", "table", 2, true
 	default:
 		return "", "", 0, false
 	}

--- a/internal/analyzer/ddl_test.go
+++ b/internal/analyzer/ddl_test.go
@@ -86,6 +86,43 @@ func TestDDLAggregatorCollectsFromEventsAndStatements(t *testing.T) {
 	}
 }
 
+func TestParseDDLStatementCreateDatabaseAndRename(t *testing.T) {
+	createDB, ok := ParseDDLStatement("CREATE DATABASE IF NOT EXISTS dogfood")
+	if !ok {
+		t.Fatal("expected CREATE DATABASE to be recognized")
+	}
+	if createDB.Operation != "CREATE DATABASE" || createDB.Object != "database" || createDB.Schema != "dogfood" {
+		t.Fatalf("unexpected CREATE DATABASE parse: %+v", createDB)
+	}
+
+	rename, ok := ParseDDLStatement("RENAME TABLE shop.old_users TO shop.users")
+	if !ok {
+		t.Fatal("expected RENAME TABLE to be recognized")
+	}
+	if rename.Operation != "RENAME TABLE" || rename.Schema != "shop" || rename.Table != "old_users" {
+		t.Fatalf("unexpected RENAME parse: %+v", rename)
+	}
+
+	trunc, ok := ParseDDLStatement("TRUNCATE audit_logs")
+	if !ok || trunc.Operation != "TRUNCATE TABLE" || trunc.Table != "audit_logs" {
+		t.Fatalf("unexpected TRUNCATE parse: ok=%v %+v", ok, trunc)
+	}
+}
+
+func TestDDLEventFromNormalizedEventUsesQuerySchemaFallback(t *testing.T) {
+	got, ok := DDLEventFromNormalizedEvent(model.NormalizedEvent{
+		EventType: "DDL",
+		Schema:    "testdb",
+		QuerySQL:  "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100))",
+	})
+	if !ok {
+		t.Fatal("expected CREATE TABLE to be recognized")
+	}
+	if got.Operation != "CREATE TABLE" || got.Schema != "testdb" || got.Table != "users" {
+		t.Fatalf("expected testdb.users CREATE TABLE, got %+v", got)
+	}
+}
+
 func TestDDLEventFromNormalizedEventIgnoresNonDDLQueries(t *testing.T) {
 	_, ok := DDLEventFromNormalizedEvent(model.NormalizedEvent{
 		EventType: "QUERY",

--- a/internal/analyzer/fixture_span_ddl_test.go
+++ b/internal/analyzer/fixture_span_ddl_test.go
@@ -1,0 +1,75 @@
+package analyzer
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"binlogviz/internal/binlog"
+)
+
+func TestOfficialFixtureRecordsQueryDDLAndRealTxnSpans(t *testing.T) {
+	path := filepath.Join("..", "binlog", "testdata", "minimal.binlog")
+	p := binlog.NewParser()
+	a := New(DefaultOptions())
+
+	if err := p.ParseFiles([]string{path}, func(raw binlog.RawEvent) error {
+		ev, err := binlog.NormalizeRawEvent(raw)
+		if err != nil {
+			return err
+		}
+		if ev == nil {
+			return nil
+		}
+		return a.Consume(*ev)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := a.Finalize()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Diagnostics.DDLEvents) == 0 {
+		t.Fatal("expected CREATE TABLE Query event on the official ROW fixture")
+	}
+	ddl := result.Diagnostics.DDLEvents[0]
+	if ddl.Operation != "CREATE TABLE" {
+		t.Fatalf("expected CREATE TABLE, got %q", ddl.Operation)
+	}
+	if ddl.Table != "users" {
+		t.Fatalf("expected table users, got %q", ddl.Table)
+	}
+
+	if len(result.Transactions) == 0 {
+		t.Fatal("expected transactions")
+	}
+	for _, txn := range result.Transactions {
+		span := txn.PositionEnd - txn.PositionStart
+		if txn.TotalRows > 0 && span <= 64 && txn.BinlogBytes <= 64 {
+			t.Fatalf("txn %s still looks XID-only (bytes=%d start=%d end=%d rows=%d)",
+				txn.TxnKey, txn.BinlogBytes, txn.PositionStart, txn.PositionEnd, txn.TotalRows)
+		}
+		if txn.BinlogBytes != span {
+			t.Fatalf("txn %s binlog_bytes=%d want pos_end-pos_start=%d", txn.TxnKey, txn.BinlogBytes, span)
+		}
+	}
+
+	if len(result.Timeseries.BinlogBytesSeries) == 0 || result.Timeseries.BinlogBytesSeries[0].Value == 0 {
+		t.Fatalf("expected minute binlog_bytes_series to accumulate row-event lengths, got %+v", result.Timeseries.BinlogBytesSeries)
+	}
+
+	var tableDDL int
+	for _, table := range result.Tables {
+		if table.Schema == "testdb" && table.Table == "users" {
+			tableDDL = table.DDLCount
+		}
+	}
+	if tableDDL == 0 {
+		t.Fatalf("expected testdb.users DDL Events > 0, tables=%+v", result.Tables)
+	}
+
+	if !strings.Contains(ddl.Statement, "CREATE TABLE") {
+		t.Fatalf("unexpected statement %q", ddl.Statement)
+	}
+}

--- a/internal/analyzer/transactions.go
+++ b/internal/analyzer/transactions.go
@@ -59,8 +59,11 @@ func (b *TransactionBuilder) Consume(ev model.NormalizedEvent) error {
 		b.handleRowsQuery(ev)
 	case "ROWS":
 		b.accumulateRowEvent(ev)
+	case "TABLE_MAP":
+		b.accumulateInTxnEvent(ev)
 	default:
-		// Ignore other event types (TABLE_MAP, etc.)
+		// Still record file coverage for in-flight events (Annotate, GTID leftovers, etc.)
+		b.accumulateInTxnEvent(ev)
 	}
 	return nil
 }
@@ -150,6 +153,13 @@ func (b *TransactionBuilder) startTransaction(ts time.Time, isExplicit bool) {
 	}
 }
 
+func (b *TransactionBuilder) accumulateInTxnEvent(ev model.NormalizedEvent) {
+	if b.current == nil {
+		return
+	}
+	b.updateBinlogCoverage(ev)
+}
+
 func (b *TransactionBuilder) accumulateRowEvent(ev model.NormalizedEvent) {
 	// If no transaction in flight, start an implicit one
 	if b.current == nil {
@@ -177,6 +187,13 @@ func (b *TransactionBuilder) finalizeTransaction() {
 		return
 	}
 
+	binlogBytes := b.current.binlogBytes
+	if b.current.binlogPathStart != "" &&
+		b.current.binlogPathStart == b.current.binlogPathEnd &&
+		b.current.positionEnd > b.current.positionStart {
+		binlogBytes = b.current.positionEnd - b.current.positionStart
+	}
+
 	txn := model.Transaction{
 		TxnKey:          b.current.txnKey,
 		StartTime:       b.current.startTime,
@@ -184,7 +201,7 @@ func (b *TransactionBuilder) finalizeTransaction() {
 		Duration:        b.current.endTime.Sub(b.current.startTime),
 		TotalRows:       b.current.totalRows,
 		EventCount:      b.current.eventCount,
-		BinlogBytes:     b.current.binlogBytes,
+		BinlogBytes:     binlogBytes,
 		BinlogPathStart: b.current.binlogPathStart,
 		BinlogPathEnd:   b.current.binlogPathEnd,
 		PositionStart:   b.current.positionStart,

--- a/internal/analyzer/transactions_test.go
+++ b/internal/analyzer/transactions_test.go
@@ -410,6 +410,80 @@ func TestTransactionBuilderUsesFirstAndLastAvailableBinlogMetadata(t *testing.T)
 	}
 }
 
+func TestTransactionBuilderUsesTxnSpanForSameFileBinlogBytes(t *testing.T) {
+	builder := NewTransactionBuilder()
+	ts := time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC)
+
+	events := []model.NormalizedEvent{
+		{Timestamp: ts, EventType: "BEGIN", BinlogPath: "mysql-bin.000008", PositionStart: 385, PositionEnd: 500, BinlogBytes: 115},
+		{Timestamp: ts, EventType: "TABLE_MAP", BinlogPath: "mysql-bin.000008", PositionStart: 500, PositionEnd: 625, BinlogBytes: 125},
+		{
+			Timestamp:     ts.Add(time.Second),
+			EventType:     "ROWS",
+			Schema:        "dogfood_big",
+			Table:         "t",
+			Operation:     "INSERT",
+			RowCount:      400000,
+			BinlogPath:    "mysql-bin.000008",
+			PositionStart: 625,
+			PositionEnd:   77914917,
+			BinlogBytes:   77914292,
+		},
+		{Timestamp: ts.Add(2 * time.Second), EventType: "XID", BinlogPath: "mysql-bin.000008", PositionStart: 77914917, PositionEnd: 77914948, BinlogBytes: 31},
+	}
+	for _, ev := range events {
+		if err := builder.Consume(ev); err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+	}
+
+	txns := builder.Completed()
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 txn, got %d", len(txns))
+	}
+	txn := txns[0]
+	if txn.PositionStart != 385 {
+		t.Fatalf("pos_start=%d, want first event 385", txn.PositionStart)
+	}
+	if txn.PositionEnd != 77914948 {
+		t.Fatalf("pos_end=%d, want XID end 77914948", txn.PositionEnd)
+	}
+	wantBytes := int64(77914948 - 385)
+	if txn.BinlogBytes != wantBytes {
+		t.Fatalf("binlog_bytes=%d, want pos_end-pos_start %d", txn.BinlogBytes, wantBytes)
+	}
+	if txn.TotalRows != 400000 {
+		t.Fatalf("rows=%d", txn.TotalRows)
+	}
+}
+
+func TestTransactionBuilderDoesNotInventStartWhenOnlyXIDIsKnown(t *testing.T) {
+	builder := NewTransactionBuilder()
+	ts := time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC)
+
+	events := []model.NormalizedEvent{
+		{Timestamp: ts, EventType: "BEGIN"},
+		{Timestamp: ts, EventType: "ROWS", Schema: "dogfood_big", Table: "t", Operation: "INSERT", RowCount: 400000},
+		{Timestamp: ts, EventType: "XID", BinlogPath: "mysql-bin.000008", PositionStart: 77914917, PositionEnd: 77914948, BinlogBytes: 31},
+	}
+	for _, ev := range events {
+		if err := builder.Consume(ev); err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+	}
+
+	txn := builder.Completed()[0]
+	if txn.PositionStart != 77914917 || txn.PositionEnd != 77914948 {
+		t.Fatalf("XID-only span should stay honest, got %d-%d", txn.PositionStart, txn.PositionEnd)
+	}
+	if txn.PositionStart == 385 {
+		t.Fatal("must not invent start position 385")
+	}
+	if txn.BinlogBytes != 31 {
+		t.Fatalf("XID-only binlog_bytes=%d, want 31", txn.BinlogBytes)
+	}
+}
+
 func BenchmarkTransactionBuilderConsumeRows(b *testing.B) {
 	ts := time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC)
 	events := []model.NormalizedEvent{

--- a/internal/binlog/README.md
+++ b/internal/binlog/README.md
@@ -7,8 +7,8 @@ Binlog parsing, raw event extraction, normalization, and parse-progress contract
 | File | Responsibility |
 |------|----------------|
 | `types.go` | Defines `RawEvent`, `Parser`, `ParseProgress`, and the optional `ProgressParser` contract used by the command layer. |
-| `parser.go` | Wraps `go-mysql-org/go-mysql/replication`, extracts raw binlog events, reuses `TableID` table names in the rows-event hot path, and emits monotonic per-input progress offsets. |
-| `normalize.go` | Converts parser-emitted `RawEvent` values into stable analyzer-facing normalized events, including a destination-reuse fast path for streaming callers. Uses first-character dispatch to reduce string comparison overhead in the hot normalization path. |
+| `parser.go` | Wraps `go-mysql-org/go-mysql/replication`, extracts raw binlog events, reuses `TableID` table names in the rows-event hot path, reconstructs MariaDB 11.4+ `LogPos=0` ranges from a running file cursor, and emits monotonic per-input progress offsets. |
+| `normalize.go` | Converts parser-emitted `RawEvent` values into stable analyzer-facing normalized events, including Query DDL (`CREATE`/`ALTER`/`DROP`/`TRUNCATE`/`RENAME`) and a destination-reuse fast path for streaming callers. Uses first-character dispatch to reduce string comparison overhead in the hot normalization path. |
 | `format.go` | Cheap Query-DML vs ROW-image observation used to guess STATEMENT/MIXED/ROW and warn when only row images are counted. |
 | `probe.go` | Scans binlog files for reusable file-level metadata such as size and chronological earliest/latest non-zero event timestamps, with internal parser-injectable helpers for reuse in tests and later planning work. |
 | `*_test.go` | Covers parser construction, helper behavior, normalization semantics, and real-fixture parser benchmarks isolating parse-only, parse+normalize, and parse+progress layers. |

--- a/internal/binlog/normalize.go
+++ b/internal/binlog/normalize.go
@@ -17,7 +17,7 @@ import (
 func NormalizeRawEvent(raw RawEvent) (*model.NormalizedEvent, error) {
 	if raw.EventType == "QUERY_EVENT" || raw.EventType == "QueryEvent" {
 		query := strings.TrimSpace(raw.Query)
-		if !strings.EqualFold(query, "BEGIN") && !strings.EqualFold(query, "COMMIT") {
+		if !strings.EqualFold(query, "BEGIN") && !strings.EqualFold(query, "COMMIT") && !hasQueryDDLPrefix(query) {
 			return nil, nil
 		}
 	} else if !isSupportedNormalizedEvent(raw.EventType) {
@@ -160,10 +160,34 @@ func normalizeQueryEventInto(raw RawEvent, dst *model.NormalizedEvent) (bool, er
 		fillNormalizedEvent(dst, raw)
 		dst.EventType = "COMMIT"
 		return true, nil
+	case hasQueryDDLPrefix(query):
+		fillNormalizedEvent(dst, raw)
+		dst.EventType = "DDL"
+		dst.QuerySQL = query
+		return true, nil
 	default:
-		// Skip other QUERY events (DDL, etc.)
+		// Skip non-transactional, non-DDL QUERY events (SET, INSERT as STATEMENT, etc.)
 		return false, nil
 	}
+}
+
+func hasQueryDDLPrefix(sql string) bool {
+	return hasWordPrefixFold(sql, "ALTER") ||
+		hasWordPrefixFold(sql, "CREATE") ||
+		hasWordPrefixFold(sql, "DROP") ||
+		hasWordPrefixFold(sql, "TRUNCATE") ||
+		hasWordPrefixFold(sql, "RENAME")
+}
+
+func hasWordPrefixFold(sql, word string) bool {
+	if len(sql) < len(word) || !strings.EqualFold(sql[:len(word)], word) {
+		return false
+	}
+	if len(sql) == len(word) {
+		return true
+	}
+	next := sql[len(word)]
+	return next == ' ' || next == '\t' || next == '\n' || next == '\r'
 }
 
 // normalizeRowsQueryEvent handles Rows_query_log_event which contains the original SQL.

--- a/internal/binlog/normalize_test.go
+++ b/internal/binlog/normalize_test.go
@@ -439,11 +439,49 @@ func TestNormalizeRowsQueryEventTruncationUTF8Boundary(t *testing.T) {
 	}
 }
 
+func TestNormalizeQueryDDLCreateTableAndDatabase(t *testing.T) {
+	createTable, err := NormalizeRawEvent(RawEvent{
+		EventType:     "QueryEvent",
+		Schema:        "testdb",
+		Query:         "CREATE TABLE users (\n  id INT PRIMARY KEY,\n  name VARCHAR(100)\n)",
+		PositionStart: 219,
+		PositionEnd:   361,
+		BinlogBytes:   142,
+		BinlogPath:    "mysql-bin.000004",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if createTable == nil {
+		t.Fatal("expected CREATE TABLE Query event to be kept")
+	}
+	if createTable.EventType != "DDL" {
+		t.Fatalf("expected EventType=DDL, got %q", createTable.EventType)
+	}
+	if !strings.Contains(createTable.QuerySQL, "CREATE TABLE users") {
+		t.Fatalf("expected QuerySQL to keep CREATE TABLE text, got %q", createTable.QuerySQL)
+	}
+	if createTable.Schema != "testdb" || createTable.PositionStart != 219 || createTable.BinlogBytes != 142 {
+		t.Fatalf("expected schema/positions preserved, got %+v", createTable)
+	}
+
+	createDB, err := NormalizeRawEvent(RawEvent{
+		EventType: "QUERY_EVENT",
+		Query:     "CREATE DATABASE IF NOT EXISTS dogfood",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if createDB == nil || createDB.EventType != "DDL" {
+		t.Fatalf("expected CREATE DATABASE to be kept as DDL, got %+v", createDB)
+	}
+}
+
 func TestNormalizeSkipsNonTransactionalQueryWithoutAllocation(t *testing.T) {
 	raw := RawEvent{
 		EventType: "QUERY_EVENT",
 		Schema:    "shop",
-		Query:     "ALTER TABLE orders ADD COLUMN note TEXT",
+		Query:     "SET timestamp=1710000000",
 	}
 
 	allocs := testing.AllocsPerRun(1000, func() {

--- a/internal/binlog/parser.go
+++ b/internal/binlog/parser.go
@@ -43,6 +43,10 @@ func (p *parser) ParseFilesFromOffset(paths []string, offset int64, handler func
 		if startOffset < 0 {
 			startOffset = 0
 		}
+		cursor := startOffset
+		if cursor == 0 {
+			cursor = binlogMagicSize
+		}
 		if err := bp.ParseFile(path, startOffset, func(ev *replication.BinlogEvent) error {
 			if ev == nil {
 				return nil
@@ -51,10 +55,10 @@ func (p *parser) ParseFilesFromOffset(paths []string, offset int64, handler func
 			raw := RawEvent{
 				Timestamp:  time.Unix(int64(ev.Header.Timestamp), 0),
 				EventType:  ev.Header.EventType.String(),
-				Position:   ev.Header.LogPos,
 				BinlogPath: path,
 			}
-			raw.PositionStart, raw.PositionEnd, raw.BinlogBytes = deriveEventPositionRange(ev.Header)
+			raw.PositionStart, raw.PositionEnd, raw.BinlogBytes, cursor = deriveEventPositionRange(ev.Header, cursor)
+			raw.Position = uint32(raw.PositionEnd)
 
 			applyBinlogEventMetadata(&raw, raw.EventType, ev.Event, tableNames)
 
@@ -77,24 +81,25 @@ func (p *parser) ParseFilesWithProgress(paths []string, onProgress func(ParsePro
 			fileSize = info.Size()
 		}
 		lastOffset := int64(0)
+		cursor := int64(binlogMagicSize)
 		if err := bp.ParseFile(path, 0, func(ev *replication.BinlogEvent) error {
 			if ev == nil {
 				return nil
 			}
 
-			offset := clampProgressOffset(int64(ev.Header.LogPos), fileSize)
+			raw := RawEvent{
+				Timestamp:  time.Unix(int64(ev.Header.Timestamp), 0),
+				EventType:  ev.Header.EventType.String(),
+				BinlogPath: path,
+			}
+			raw.PositionStart, raw.PositionEnd, raw.BinlogBytes, cursor = deriveEventPositionRange(ev.Header, cursor)
+			raw.Position = uint32(raw.PositionEnd)
+
+			offset := clampProgressOffset(raw.PositionEnd, fileSize)
 			lastOffset = maxInt64(lastOffset, offset)
 			if onProgress != nil {
 				onProgress(ParseProgress{Path: path, Index: index, Offset: lastOffset})
 			}
-
-			raw := RawEvent{
-				Timestamp:  time.Unix(int64(ev.Header.Timestamp), 0),
-				EventType:  ev.Header.EventType.String(),
-				Position:   ev.Header.LogPos,
-				BinlogPath: path,
-			}
-			raw.PositionStart, raw.PositionEnd, raw.BinlogBytes = deriveEventPositionRange(ev.Header)
 
 			applyBinlogEventMetadata(&raw, raw.EventType, ev.Event, tableNames)
 
@@ -167,22 +172,41 @@ func applyRowsEventTableName(raw *RawEvent, event *replication.RowsEvent, tableN
 	}
 }
 
-func deriveEventPositionRange(header *replication.EventHeader) (int64, int64, int64) {
+// binlogMagicSize is the 4-byte BINLOG magic at the start of every file.
+const binlogMagicSize = 4
+
+// deriveEventPositionRange returns file-relative [start, end) and byte length.
+// MariaDB 11.4+ leaves LogPos=0 on many events (BEGIN, TABLE_MAP, WriteRows);
+// only XID typically has a real LogPos. When LogPos is 0 we reconstruct from
+// the running cursor so large transactions are not recorded as a 31-byte XID.
+func deriveEventPositionRange(header *replication.EventHeader, cursor int64) (start, end, size, next int64) {
 	if header == nil {
-		return 0, 0, 0
+		return 0, 0, 0, cursor
 	}
 
-	end := int64(header.LogPos)
-	size := int64(header.EventSize)
-	start := end - size
-	if start < 0 {
-		start = 0
-	}
-	if end < start {
-		end = start
+	eventSize := int64(header.EventSize)
+	if header.LogPos > 0 {
+		end = int64(header.LogPos)
+		start = end - eventSize
+		if start < 0 {
+			start = 0
+		}
+		if end < start {
+			end = start
+		}
+		return start, end, end - start, end
 	}
 
-	return start, end, end - start
+	// LogPos=0: reconstruct from the running file cursor (MariaDB 11.4+).
+	if cursor <= 0 {
+		cursor = binlogMagicSize
+	}
+	if eventSize <= 0 {
+		return cursor, cursor, 0, cursor
+	}
+	start = cursor
+	end = cursor + eventSize
+	return start, end, eventSize, end
 }
 
 func clampProgressOffset(offset, fileSize int64) int64 {

--- a/internal/binlog/probe_test.go
+++ b/internal/binlog/probe_test.go
@@ -238,47 +238,90 @@ func TestDeriveEventPositionRange(t *testing.T) {
 	tests := []struct {
 		name      string
 		header    *replication.EventHeader
+		cursor    int64
 		wantStart int64
 		wantEnd   int64
 		wantBytes int64
+		wantNext  int64
 	}{
 		{
 			name:      "nil header",
 			header:    nil,
+			cursor:    4,
 			wantStart: 0,
 			wantEnd:   0,
 			wantBytes: 0,
+			wantNext:  4,
 		},
 		{
 			name:      "standard event",
 			header:    &replication.EventHeader{LogPos: 123, EventSize: 19},
+			cursor:    4,
 			wantStart: 104,
 			wantEnd:   123,
 			wantBytes: 19,
+			wantNext:  123,
 		},
 		{
 			name:      "underflow clamps start",
 			header:    &replication.EventHeader{LogPos: 10, EventSize: 40},
+			cursor:    4,
 			wantStart: 0,
 			wantEnd:   10,
 			wantBytes: 10,
+			wantNext:  10,
 		},
 		{
-			name:      "zero sized event",
+			name:      "zero sized event with LogPos",
 			header:    &replication.EventHeader{LogPos: 20, EventSize: 0},
+			cursor:    20,
 			wantStart: 20,
 			wantEnd:   20,
 			wantBytes: 0,
+			wantNext:  20,
+		},
+		{
+			name:      "MariaDB 11.4 zero LogPos reconstructs from cursor",
+			header:    &replication.EventHeader{LogPos: 0, EventSize: 8000},
+			cursor:    385,
+			wantStart: 385,
+			wantEnd:   8385,
+			wantBytes: 8000,
+			wantNext:  8385,
+		},
+		{
+			name:      "MariaDB 11.4 XID still uses real LogPos",
+			header:    &replication.EventHeader{LogPos: 77914948, EventSize: 31},
+			cursor:    77914917,
+			wantStart: 77914917,
+			wantEnd:   77914948,
+			wantBytes: 31,
+			wantNext:  77914948,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotStart, gotEnd, gotBytes := deriveEventPositionRange(tt.header)
-			if gotStart != tt.wantStart || gotEnd != tt.wantEnd || gotBytes != tt.wantBytes {
-				t.Fatalf("expected (%d,%d,%d), got (%d,%d,%d)", tt.wantStart, tt.wantEnd, tt.wantBytes, gotStart, gotEnd, gotBytes)
+			gotStart, gotEnd, gotBytes, gotNext := deriveEventPositionRange(tt.header, tt.cursor)
+			if gotStart != tt.wantStart || gotEnd != tt.wantEnd || gotBytes != tt.wantBytes || gotNext != tt.wantNext {
+				t.Fatalf("expected (%d,%d,%d,next=%d), got (%d,%d,%d,next=%d)",
+					tt.wantStart, tt.wantEnd, tt.wantBytes, tt.wantNext, gotStart, gotEnd, gotBytes, gotNext)
 			}
 		})
+	}
+}
+
+func TestMariaDBZeroLogPosRowEventsKeepNonZeroBytes(t *testing.T) {
+	// Dogfood #18: MariaDB 11.8 WRITE_ROWS often have LogPos=0 and EventSize>0.
+	// Reconstructing from the running cursor keeps minute binlog_bytes off zero.
+	cursor := int64(625)
+	start, end, bytes, next := deriveEventPositionRange(&replication.EventHeader{LogPos: 0, EventSize: 8192}, cursor)
+	if start != 625 || end != 8817 || bytes != 8192 || next != 8817 {
+		t.Fatalf("row event reconstruction = start=%d end=%d bytes=%d next=%d", start, end, bytes, next)
+	}
+	xidStart, xidEnd, xidBytes, _ := deriveEventPositionRange(&replication.EventHeader{LogPos: 77914948, EventSize: 31}, next)
+	if xidStart != 77914917 || xidEnd != 77914948 || xidBytes != 31 {
+		t.Fatalf("XID range = start=%d end=%d bytes=%d", xidStart, xidEnd, xidBytes)
 	}
 }
 

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1079,6 +1079,14 @@
     "description": "Binlog span label",
     "other": "Binlog Span"
   },
+  "report.html.analyze.copy": {
+    "description": "Copy mysqlbinlog command button",
+    "other": "Copy"
+  },
+  "report.html.analyze.copied": {
+    "description": "Copy button confirmation",
+    "other": "Copied"
+  },
   "report.html.analyze.widestTag": {
     "description": "Widest transaction tag",
     "other": "widest"

--- a/internal/i18n/locales/zh-CN.json
+++ b/internal/i18n/locales/zh-CN.json
@@ -1079,6 +1079,14 @@
     "description": "Binlog 跨度标签",
     "other": "Binlog 跨度"
   },
+  "report.html.analyze.copy": {
+    "description": "复制 mysqlbinlog 命令按钮",
+    "other": "复制"
+  },
+  "report.html.analyze.copied": {
+    "description": "复制按钮确认",
+    "other": "已复制"
+  },
   "report.html.analyze.widestTag": {
     "description": "最宽事务标签",
     "other": "最宽"

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -12,7 +12,8 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 | `json.go` | Serializes the stable analyze JSON report shape, including optional top-level snapshot metadata, and applies SQL context field visibility rules. |
 | `markdown.go` | Renders GitHub-flavored Markdown output. |
 | `html.go` | Renders the self-contained HTML report, including responsive activity-chart layout and ECharts data preparation. |
-| `*_test.go` | Verifies diagnostic text defaults, opt-in detail sections, JSON field stability, snapshot behavior, and SQL context mode behavior. |
+| `mysqlbinlog.go` | Builds copy-paste `mysqlbinlog` commands from usable txn spans; omits `--start-position` when only an XID interval is known. |
+| `*_test.go` | Verifies diagnostic text defaults, opt-in detail sections, JSON field stability, snapshot behavior, SQL context mode behavior, and mysqlbinlog command emission. |
 
 ## Interfaces
 

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -172,14 +172,15 @@ type htmlDDLEvent struct {
 }
 
 type htmlTxnDiagnostic struct {
-	TxnKey       string
-	Rows         int
-	Events       int
-	Duration     string
-	BinlogBytes  int
-	Tables       []htmlTxnTable
-	Location     string
-	QuerySummary string
+	TxnKey         string
+	Rows           int
+	Events         int
+	Duration       string
+	BinlogBytes    int
+	Tables         []htmlTxnTable
+	Location       string
+	QuerySummary   string
+	MysqlbinlogCmd string
 }
 
 type htmlTxnTable struct {
@@ -542,14 +543,15 @@ func formatFileSize(bytes int64) string {
 
 func buildHTMLTxnDiagnostic(txn model.Transaction) htmlTxnDiagnostic {
 	return htmlTxnDiagnostic{
-		TxnKey:       txn.TxnKey,
-		Rows:         txn.TotalRows,
-		Events:       txn.EventCount,
-		Duration:     txn.Duration.String(),
-		BinlogBytes:  int(txn.BinlogBytes),
-		Tables:       sortedTxnTables(txn.Tables),
-		Location:     formatBinlogSpan(txn),
-		QuerySummary: txn.QuerySummary,
+		TxnKey:         txn.TxnKey,
+		Rows:           txn.TotalRows,
+		Events:         txn.EventCount,
+		Duration:       txn.Duration.String(),
+		BinlogBytes:    int(txn.BinlogBytes),
+		Tables:         sortedTxnTables(txn.Tables),
+		Location:       formatBinlogSpan(txn),
+		QuerySummary:   txn.QuerySummary,
+		MysqlbinlogCmd: mysqlbinlogCmd(txn),
 	}
 }
 

--- a/internal/report/html_template.go
+++ b/internal/report/html_template.go
@@ -244,6 +244,19 @@ const htmlReportTemplate = `<!DOCTYPE html>
   .key-finding-badge.critical { background: rgba(248,81,73,0.15); color: var(--danger); }
   .key-finding-badge.warning  { background: rgba(251,191,36,0.15); color: var(--warn); }
   .key-finding-badge.info     { background: rgba(37,99,235,0.15); color: var(--primary); }
+  .mysqlbinlog-row { display: flex; align-items: flex-start; gap: 8px; margin-top: 6px; }
+  .mysqlbinlog-cmd { font-family: 'Fira Code', monospace; font-size: 11px; color: var(--accent); word-break: break-all; }
+  .copy-btn {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--primary);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .copy-btn:hover { border-color: var(--primary); }
 
   /* Section */
   .section {
@@ -762,6 +775,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
+              {{if .MysqlbinlogCmd}}<div class="mysqlbinlog-row"><code class="mysqlbinlog-cmd">{{.MysqlbinlogCmd}}</code><button type="button" class="copy-btn" data-copy="{{.MysqlbinlogCmd}}">{{t "report.html.analyze.copy"}}</button></div>{{end}}
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}
               <div class="diagnostic-tables">
@@ -783,6 +797,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
+              {{if .MysqlbinlogCmd}}<div class="mysqlbinlog-row"><code class="mysqlbinlog-cmd">{{.MysqlbinlogCmd}}</code><button type="button" class="copy-btn" data-copy="{{.MysqlbinlogCmd}}">{{t "report.html.analyze.copy"}}</button></div>{{end}}
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}
               <div class="diagnostic-tables">
@@ -804,6 +819,7 @@ const htmlReportTemplate = `<!DOCTYPE html>
             <div class="diagnostic-body">
               {{if .Location}}<div>{{t "report.html.analyze.binlogSpan"}}: {{.Location}}</div>{{end}}
               <div>{{t "report.html.analyze.binlogBytes"}}: {{fmtIntHTML .BinlogBytes}}</div>
+              {{if .MysqlbinlogCmd}}<div class="mysqlbinlog-row"><code class="mysqlbinlog-cmd">{{.MysqlbinlogCmd}}</code><button type="button" class="copy-btn" data-copy="{{.MysqlbinlogCmd}}">{{t "report.html.analyze.copy"}}</button></div>{{end}}
               {{if .QuerySummary}}<div>{{.QuerySummary}}</div>{{end}}
               {{if .Tables}}
               <div class="diagnostic-tables">
@@ -1315,6 +1331,18 @@ const htmlReportTemplate = `<!DOCTYPE html>
     window.addEventListener('resize', function() { c.resize(); });
   }
   renderThroughputChart();
+
+  document.querySelectorAll('button.copy-btn[data-copy]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var text = btn.getAttribute('data-copy') || '';
+      if (!text || !navigator.clipboard) { return; }
+      navigator.clipboard.writeText(text).then(function() {
+        var prev = btn.textContent;
+        btn.textContent = '{{t "report.html.analyze.copied"}}';
+        setTimeout(function() { btn.textContent = prev; }, 1200);
+      });
+    });
+  });
 
   // Init
           var saved = localStorage.getItem('bvtheme') || 'nebula';

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -165,6 +165,7 @@ type jsonTransaction struct {
 	QuerySQL           string         `json:"query_sql,omitempty"`
 	QueryTruncated     *bool          `json:"query_truncated,omitempty"`
 	QueryOriginalBytes *int           `json:"query_original_bytes,omitempty"`
+	MysqlbinlogCmd     string         `json:"mysqlbinlog_cmd,omitempty"`
 }
 
 type jsonPatternStats struct {
@@ -549,6 +550,7 @@ func convertTransactions(txns []model.Transaction, mode SQLContextMode) []jsonTr
 				jt.QueryOriginalBytes = intPtr(t.QueryContext.OriginalBytes)
 			}
 		}
+		jt.MysqlbinlogCmd = mysqlbinlogCmd(t)
 		result[i] = jt
 	}
 	return result

--- a/internal/report/mysqlbinlog.go
+++ b/internal/report/mysqlbinlog.go
@@ -1,0 +1,108 @@
+// Package report builds copy-paste mysqlbinlog commands from recorded transaction spans.
+// input: analyzer-produced Transaction positions after real start/end reconstruction.
+// output: a mysqlbinlog command string, or empty when the span is XID-only / unusable.
+// pos: shared helper for text, JSON, and HTML Copy so #23 never invents --start-position.
+// note: if this file changes, keep internal/report/README.md synchronized.
+package report
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"binlogviz/internal/model"
+)
+
+// maxCommitXIDSpanBytes is the largest recorded span treated as a commit XID
+// rather than a usable --start-position. Dogfood #18 records a 31-byte XID.
+const maxCommitXIDSpanBytes = 64
+
+func txnRecordedSpanBytes(txn model.Transaction) int64 {
+	if txn.BinlogBytes > 0 {
+		return txn.BinlogBytes
+	}
+	if txn.PositionStart > 0 && txn.PositionEnd > txn.PositionStart {
+		return txn.PositionEnd - txn.PositionStart
+	}
+	return 0
+}
+
+func txnSpanIsXIDOnly(txn model.Transaction) bool {
+	span := txnRecordedSpanBytes(txn)
+	if span <= 0 || span > maxCommitXIDSpanBytes {
+		return false
+	}
+	return txn.EventCount > 1 || txn.TotalRows > 1
+}
+
+func txnSpanUsableForMysqlbinlog(txn model.Transaction) bool {
+	if txnSpanIsXIDOnly(txn) {
+		return false
+	}
+	if txn.PositionStart <= 0 || txn.PositionEnd <= txn.PositionStart {
+		return false
+	}
+	if txn.BinlogPathStart == "" {
+		return false
+	}
+	return true
+}
+
+func mysqlbinlogCmd(txn model.Transaction) string {
+	if !txnSpanUsableForMysqlbinlog(txn) {
+		return ""
+	}
+	startFile := filepath.Base(txn.BinlogPathStart)
+	endFile := startFile
+	if txn.BinlogPathEnd != "" {
+		endFile = filepath.Base(txn.BinlogPathEnd)
+	}
+	const flags = "--base64-output=DECODE-ROWS -v"
+	if startFile == endFile {
+		return fmt.Sprintf("mysqlbinlog %s --start-position=%d --stop-position=%d %s",
+			flags, txn.PositionStart, txn.PositionEnd, startFile)
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("mysqlbinlog %s --start-position=%d %s", flags, txn.PositionStart, startFile),
+		fmt.Sprintf("mysqlbinlog %s --stop-position=%d %s", flags, txn.PositionEnd, endFile),
+	}, "\n")
+}
+
+func formatTxnEvidenceLocation(txn model.Transaction) string {
+	if txn.BinlogPathStart != "" {
+		txn.BinlogPathStart = filepath.Base(txn.BinlogPathStart)
+	}
+	if txn.BinlogPathEnd != "" {
+		txn.BinlogPathEnd = filepath.Base(txn.BinlogPathEnd)
+	}
+	loc := formatSuspiciousLocation(txn)
+	if txn.BinlogPathStart == "" && txn.PositionStart == 0 && txn.PositionEnd == 0 {
+		return loc
+	}
+	span := txnRecordedSpanBytes(txn)
+	if span <= 0 && txn.TotalRows <= 0 {
+		return loc
+	}
+	parts := make([]string, 0, 2)
+	if span > 0 {
+		parts = append(parts, formatCompactBytes(span))
+	}
+	if txn.TotalRows > 0 {
+		parts = append(parts, fmt.Sprintf("%d rows", txn.TotalRows))
+	}
+	if len(parts) == 0 {
+		return loc
+	}
+	return loc + " (" + strings.Join(parts, ", ") + ")"
+}
+
+func formatCompactBytes(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%dMB", (n+500_000)/1_000_000)
+	case n >= 1000:
+		return fmt.Sprintf("%dKB", (n+500)/1000)
+	default:
+		return fmt.Sprintf("%dB", n)
+	}
+}

--- a/internal/report/mysqlbinlog_test.go
+++ b/internal/report/mysqlbinlog_test.go
@@ -1,0 +1,169 @@
+package report
+
+import (
+	"strings"
+	"testing"
+
+	"binlogviz/internal/model"
+)
+
+func TestMysqlbinlogCmdForUsableSameFileSpan(t *testing.T) {
+	txn := model.Transaction{
+		TotalRows:       400000,
+		EventCount:      9524,
+		BinlogBytes:     77914563,
+		BinlogPathStart: "/data/mysql/mysql-bin.000008",
+		BinlogPathEnd:   "/data/mysql/mysql-bin.000008",
+		PositionStart:   385,
+		PositionEnd:     77914948,
+	}
+	got := mysqlbinlogCmd(txn)
+	want := "mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008"
+	if got != want {
+		t.Fatalf("mysqlbinlog_cmd=%q, want %q", got, want)
+	}
+	loc := formatTxnEvidenceLocation(txn)
+	if loc != "mysql-bin.000008:385-77914948 (78MB, 400000 rows)" &&
+		loc != "/data/mysql/mysql-bin.000008:385-77914948 (78MB, 400000 rows)" {
+		t.Fatalf("evidence location=%q", loc)
+	}
+}
+
+func TestMysqlbinlogCmdOmittedForXIDOnlySpan(t *testing.T) {
+	txn := model.Transaction{
+		TotalRows:       400000,
+		EventCount:      9524,
+		BinlogBytes:     31,
+		BinlogPathStart: "mysql-bin.000008",
+		BinlogPathEnd:   "mysql-bin.000008",
+		PositionStart:   77914917,
+		PositionEnd:     77914948,
+	}
+	if cmd := mysqlbinlogCmd(txn); cmd != "" {
+		t.Fatalf("XID-only span must not emit mysqlbinlog_cmd, got %q", cmd)
+	}
+}
+
+func TestMysqlbinlogCmdCrossFileListsBothFiles(t *testing.T) {
+	txn := model.Transaction{
+		TotalRows:       20,
+		EventCount:      4,
+		BinlogBytes:     4096,
+		BinlogPathStart: "mysql-bin.000044",
+		BinlogPathEnd:   "mysql-bin.000045",
+		PositionStart:   300,
+		PositionEnd:     520,
+	}
+	got := mysqlbinlogCmd(txn)
+	if !strings.Contains(got, "--start-position=300 mysql-bin.000044") {
+		t.Fatalf("missing first-file start: %q", got)
+	}
+	if !strings.Contains(got, "--stop-position=520 mysql-bin.000045") {
+		t.Fatalf("missing last-file stop: %q", got)
+	}
+	if strings.Contains(got, "--start-position=300 --stop-position=520 mysql-bin.000044") {
+		t.Fatalf("must not pretend a cross-file span is one file: %q", got)
+	}
+}
+
+func TestRenderJSONIncludesMysqlbinlogCmdOnlyWhenUsable(t *testing.T) {
+	forceEnglishReportLocale(t)
+	usable := model.Transaction{
+		TxnKey:          "txn-real",
+		TotalRows:       400000,
+		EventCount:      10,
+		BinlogBytes:     77914563,
+		BinlogPathStart: "mysql-bin.000008",
+		BinlogPathEnd:   "mysql-bin.000008",
+		PositionStart:   385,
+		PositionEnd:     77914948,
+	}
+	xidOnly := model.Transaction{
+		TxnKey:          "txn-xid",
+		TotalRows:       400000,
+		EventCount:      9524,
+		BinlogBytes:     31,
+		BinlogPathStart: "mysql-bin.000008",
+		BinlogPathEnd:   "mysql-bin.000008",
+		PositionStart:   77914917,
+		PositionEnd:     77914948,
+	}
+
+	out, err := RenderJSON(model.AnalysisResult{
+		Diagnostics: model.Diagnostics{
+			LargestTransactions: []model.Transaction{usable, xidOnly},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"mysqlbinlog_cmd": "mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008"`) {
+		t.Fatalf("expected usable mysqlbinlog_cmd in JSON\n%s", out)
+	}
+	// Second txn is XID-only; the invented start must not appear, and cmd should be omitted for that object.
+	if strings.Count(out, `"mysqlbinlog_cmd"`) != 1 {
+		t.Fatalf("expected mysqlbinlog_cmd only on the usable txn, got\n%s", out)
+	}
+	if strings.Contains(out, "--start-position=77914917") {
+		t.Fatalf("must not emit XID start as --start-position\n%s", out)
+	}
+}
+
+func TestRenderTextAndHTMLIncludeMysqlbinlogCopy(t *testing.T) {
+	forceEnglishReportLocale(t)
+	result := model.AnalysisResult{
+		Diagnostics: model.Diagnostics{
+			LargestTransactions: []model.Transaction{{
+				TxnKey:          "txn-1",
+				TotalRows:       400000,
+				EventCount:      10,
+				BinlogBytes:     77914563,
+				BinlogPathStart: "mysql-bin.000008",
+				BinlogPathEnd:   "mysql-bin.000008",
+				PositionStart:   385,
+				PositionEnd:     77914948,
+				Tables:          map[string]int{"dogfood_big.t": 400000},
+			}},
+		},
+	}
+
+	textOut, err := RenderText(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(textOut, "mysql-bin.000008:385-77914948 (78MB, 400000 rows)") {
+		t.Fatalf("expected span evidence in text\n%s", textOut)
+	}
+	if !strings.Contains(textOut, "mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008") {
+		t.Fatalf("expected mysqlbinlog command in text\n%s", textOut)
+	}
+
+	htmlOut, err := RenderHTML(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(htmlOut, "mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008") {
+		t.Fatalf("expected mysqlbinlog command in HTML\n%s", htmlOut)
+	}
+	if !strings.Contains(htmlOut, `data-copy="mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008"`) {
+		t.Fatal("expected HTML Copy button")
+	}
+}
+
+func TestRenderTextDDLTimelineListsOperations(t *testing.T) {
+	forceEnglishReportLocale(t)
+	out, err := RenderText(model.AnalysisResult{
+		Diagnostics: model.Diagnostics{
+			DDLEvents: []model.DDLEvent{
+				{Operation: "CREATE DATABASE", Schema: "dogfood"},
+				{Operation: "CREATE TABLE", Schema: "dogfood", Table: "users"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "DDL Timeline: 2 (CREATE DATABASE, CREATE TABLE)") {
+		t.Fatalf("expected DDL timeline summary, got\n%s", out)
+	}
+}

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -62,7 +62,7 @@ func renderDiagnosticSummary(buf *strings.Builder, result model.AnalysisResult) 
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalTransactions"), summary.TotalTransactions))
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalRows"), summary.TotalRows))
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalEvents"), summary.TotalEvents))
-	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.html.analyze.ddlTimeline"), len(result.Diagnostics.DDLEvents)))
+	buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.html.analyze.ddlTimeline"), formatDDLTimelineSummary(result.Diagnostics.DDLEvents)))
 	buf.WriteString("\n")
 }
 
@@ -212,15 +212,24 @@ func renderTopTransactions(buf *strings.Builder, result model.AnalysisResult, to
 	lines := make([]string, 0, limit*3)
 	for _, txn := range limitTransactions(result.Diagnostics.LargestTransactions, limit) {
 		lines = append(lines, fmt.Sprintf("  %s: %s rows=%d tables=%d file=%s",
-			i18n.T("report.text.largestTransaction"), txn.TxnKey, txn.TotalRows, len(txn.Tables), formatSuspiciousLocation(txn)))
+			i18n.T("report.text.largestTransaction"), txn.TxnKey, txn.TotalRows, len(txn.Tables), formatTxnEvidenceLocation(txn)))
+		if cmd := mysqlbinlogCmd(txn); cmd != "" {
+			lines = append(lines, "    "+cmd)
+		}
 	}
 	for _, txn := range limitTransactions(result.Diagnostics.LongestTransactions, limit) {
 		lines = append(lines, fmt.Sprintf("  %s: %s dur=%s rows=%d file=%s",
 			i18n.T("report.text.longestTransaction"), txn.TxnKey, formatDuration(txn.Duration), txn.TotalRows, formatSuspiciousLocation(txn)))
+		if cmd := mysqlbinlogCmd(txn); cmd != "" {
+			lines = append(lines, "    "+cmd)
+		}
 	}
 	for _, txn := range limitTransactions(result.Diagnostics.WidestTransactions, limit) {
 		lines = append(lines, fmt.Sprintf("  %s: %s tables=%d rows=%d file=%s",
 			i18n.T("report.text.widestTransaction"), txn.TxnKey, len(txn.Tables), txn.TotalRows, formatSuspiciousLocation(txn)))
+		if cmd := mysqlbinlogCmd(txn); cmd != "" {
+			lines = append(lines, "    "+cmd)
+		}
 	}
 
 	if len(lines) == 0 {
@@ -432,6 +441,29 @@ func formatSuspiciousLocation(txn model.Transaction) string {
 		return i18n.T("time.notAvailable")
 	}
 	return formatBinlogLocationWithEnd(txn.BinlogPathStart, txn.PositionStart, txn.BinlogPathEnd, txn.PositionEnd)
+}
+
+func formatDDLTimelineSummary(events []model.DDLEvent) string {
+	if len(events) == 0 {
+		return "0"
+	}
+	seen := make(map[string]struct{}, len(events))
+	ops := make([]string, 0, len(events))
+	for _, event := range events {
+		op := strings.TrimSpace(event.Operation)
+		if op == "" {
+			continue
+		}
+		if _, ok := seen[op]; ok {
+			continue
+		}
+		seen[op] = struct{}{}
+		ops = append(ops, op)
+	}
+	if len(ops) == 0 {
+		return fmt.Sprintf("%d", len(events))
+	}
+	return fmt.Sprintf("%d (%s)", len(events), strings.Join(ops, ", "))
 }
 
 func minInt(a, b int) int {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes operator dogfood bugs #18, #16, and #23. Does not rewrite the HTML incident page in #17 and does not touch #8 / #9 / #15.

## Investigation

**#18 is right about live MariaDB, slightly off about the 5.7 fixture.** On MariaDB 11.4+ (including 11.8.6), `LogPos` is 0 on BEGIN / TABLE_MAP / WriteRows. Only XID typically has a real `LogPos`. `deriveEventPositionRange` then clamped those events to `0,0,0`, so a 400k-row / ~78MB txn was stored as `pos_start=77914917`, `pos_end=77914948`, `binlog_bytes=31`, and the minute `binlog_bytes_series` stayed 0.

The official MySQL 5.7 `minimal.binlog` already recorded real BEGIN→XID spans (`426-630`, 204 bytes after this change). The 31-byte-only shape shows up on MariaDB 11.4+ file parses, not because the analyzer ignored row events that already had positions.

If only an XID interval is known, we still do **not** invent `pos_start=385`. That stays honest for #17’s XID-only rendering.

**#16 is exactly right.** Query `CREATE DATABASE` / `CREATE TABLE` were dropped in normalize (`// Skip other QUERY events (DDL, etc.)`), so `ddl_events` and the timeline stayed empty on real ROW files.

**#23 depends on #18.** Once the span is usable, emit a copy-paste `mysqlbinlog` command. If the span is still XID-only, do not emit `--start-position`.

## Changes

- Reconstruct `LogPos=0` events from a running file cursor (same idea as go-mysql’s `FillZeroLogPos`).
- Same-file txn `binlog_bytes = pos_end - pos_start` (first in-txn event through XID). Minute series still sums **row-event** lengths.
- Keep Query DDL (`CREATE` / `ALTER` / `DROP` / `TRUNCATE` / `RENAME`, including `CREATE DATABASE`) in `ddl_events` and `DDL Timeline: N (CREATE DATABASE, CREATE TABLE)`.
- Text / HTML (Copy) / JSON `mysqlbinlog_cmd` only when `pos_end > pos_start` and the span is not an XID-only 31-byte interval.

Example (usable span):

```
mysqlbinlog --base64-output=DECODE-ROWS -v --start-position=385 --stop-position=77914948 mysql-bin.000008
```

Text evidence: `mysql-bin.000008:385-77914948 (78MB, 400000 rows)`.

## How to check

```bash
go test ./internal/binlog/ ./internal/analyzer/ ./internal/report/ ./cmd/binlogviz/ -count=1
```

On a MariaDB 11.8 large-txn file, `txn-1` should no longer be a 31-byte XID span, `ddl_events` should list Query CREATE/ALTER/DROP, and `mysqlbinlog_cmd` should appear only when the span is usable.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48b3dab8-ffae-4491-aee1-fd5cf4aef09e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48b3dab8-ffae-4491-aee1-fd5cf4aef09e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

