### PR TITLE
fix: remaining operator docs, sample binlog, text brief, and write-shape reps

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,8 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
+      - src: cmd/binlogviz/testdata/minimal.binlog
+        dst: testdata/minimal.binlog
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,20 @@ BinlogViz is a local CLI for MySQL `ROW` binlog analysis. It is built for DBAs a
 
 ## Start Here
 
-If you already have local binlog files, these are the fastest paths to useful output:
+BinlogViz is a **fast ROW-binlog summary**: hot tables, write shapes, and before/after compare. A 510 MB file is typically a few seconds.
 
-### Inspect one file quickly
+It is **not** a full STATEMENT/MIXED analyzer — those files come back empty or undercounted (only ROW images are counted). Printed positions are file evidence; use them as `mysqlbinlog --start-position` only when the reported span covers the transaction events, not an XID-only interval.
+
+### Verify install with the sample ROW binlog
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
+```
+
+The same 1500-byte fixture lives at `cmd/binlogviz/testdata/minimal.binlog` in the repo. Future release archives also include `testdata/minimal.binlog`.
+
+### Inspect one of your own files
 
 ```bash
 binlogviz analyze mysql-bin.000123
@@ -188,12 +199,27 @@ BinlogViz is optimized for these common DBA questions:
 
 ### Preferred on macOS: Homebrew Cask
 
+Homebrew is **macOS-only**. Linux users should use the tarball or `install.sh` one-liner below.
+
 ```bash
 brew tap Fanduzi/binlogviz
 brew install --cask binlogviz
 ```
 
 This path installs the prebuilt release artifact and removes the macOS quarantine attribute during installation, so you do not need to install DuckDB separately.
+
+### Linux: tarball or install.sh
+
+```bash
+# install.sh (current release)
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.21.0/install.sh
+sh ./install.sh --version v0.21.0
+
+# or linux/amd64 tarball
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.21.0/binlogviz_0.21.0_linux_amd64.tar.gz
+tar -xzf binlogviz_0.21.0_linux_amd64.tar.gz
+install ./binlogviz /usr/local/bin/binlogviz
+```
 
 ### Preferred cross-platform fallback: Download a Release Artifact
 
@@ -265,7 +291,8 @@ The maintainer-facing smoke path verifies that one built archive can:
 ### 1. Validate one file before scaling up
 
 ```bash
-binlogviz analyze mysql-bin.000123
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
 ```
 
 Use this when you want the fastest check that:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -16,9 +16,20 @@ BinlogViz 是一个面向 DBA 和运维人员的本地 MySQL `ROW` binlog 分析
 
 ## 从这里开始
 
-如果你已经拿到了本地 binlog 文件，下面这些命令就是最快能看到有价值结果的路径：
+BinlogViz 做的是 **ROW binlog 的快速摘要**：热表、写入形态、上线前后 compare。510 MB 级文件通常只要数秒。
 
-### 快速检查单个文件
+它**不是** STATEMENT / MIXED 全量分析器——这类文件会空成功或只统计到 ROW 子集。报告里的位置是文件证据；只有当跨度覆盖事务事件、而不是只有 XID 区间时，才把它当作 `mysqlbinlog --start-position`。
+
+### 用样例 ROW binlog 验证安装
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
+```
+
+同一份 1500 字节样本在仓库的 `cmd/binlogviz/testdata/minimal.binlog`。后续 release 归档也会带上 `testdata/minimal.binlog`。
+
+### 检查你自己的文件
 
 ```bash
 binlogviz analyze mysql-bin.000123
@@ -188,12 +199,27 @@ BinlogViz 重点服务这些 DBA 常见问题：
 
 ### macOS 首选：Homebrew Cask
 
+Homebrew **仅适用于 macOS**。Linux 请用下面的 tarball 或 `install.sh`。
+
 ```bash
 brew tap Fanduzi/binlogviz
 brew install --cask binlogviz
 ```
 
 这条路径会安装预编译 release artifact，并在安装时移除 macOS quarantine 属性；用户不需要额外安装 DuckDB。
+
+### Linux：tarball 或 install.sh
+
+```bash
+# install.sh（当前版本）
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.21.0/install.sh
+sh ./install.sh --version v0.21.0
+
+# 或 linux/amd64 tarball
+curl -fsSLO https://github.com/Fanduzi/BinlogVisualizer/releases/download/v0.21.0/binlogviz_0.21.0_linux_amd64.tar.gz
+tar -xzf binlogviz_0.21.0_linux_amd64.tar.gz
+install ./binlogviz /usr/local/bin/binlogviz
+```
 
 ### 通用备选：下载 Release Artifact
 
@@ -252,7 +278,8 @@ binlogviz version
 ### 1. 先用一个文件验证分析链路
 
 ```bash
-binlogviz analyze mysql-bin.000123
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
 ```
 
 适用场景：

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1118,12 +1118,12 @@
         <section class="hero">
           <div class="container hero-content">
             <div class="hero-badge reveal visible">
-              <span class="eyebrow" data-i18n="hero.badge">v0.20.3 — replace offset probing with sequential inference</span>
+              <span class="eyebrow" data-i18n="hero.badge">v0.21.0 — HTML file output and table operation breakdown</span>
             </div>
             <h1 class="reveal visible" data-i18n="hero.title">Turn MySQL ROW binlogs
 into incident-ready reports</h1>
-            <p class="hero-sub reveal visible" data-i18n="hero.sub">BinlogViz helps DBAs and on-call engineers move from raw binlog events to a readable workload story.
-Find hot tables, large transactions, write spikes, and incident-window changes, then save named baselines, compare current versus baseline, and hand the result to your team in a format they can actually use.</p>
+            <p class="hero-sub reveal visible" data-i18n="hero.sub">Fast ROW-binlog summary: hot tables, write shapes, before/after compare. A 510 MB file is typically a few seconds.
+STATEMENT or MIXED files come back empty or undercounted. Printed positions are file evidence — use them as mysqlbinlog --start-position only when the span covers the transaction events, not an XID-only interval.</p>
             <div class="hero-actions reveal visible">
               <a href="#install" class="btn-primary" data-i18n="hero.primary">Install BinlogViz</a>
               <a href="#outputs" class="btn-secondary" data-i18n="hero.secondary">See output surfaces</a>
@@ -1383,22 +1383,22 @@ It has published docs, explicit output contracts, release notes around HTML and 
               <article class="release-spotlight">
                 <div class="release-kicker" data-i18n="releases.currentLabel">Current release</div>
                 <div class="release-version-row">
-                  <div class="release-version">v0.20.3</div>
+                  <div class="release-version">v0.21.0</div>
                   <span class="tag tag-new" style="font-size:0.65rem;" data-i18n="releases.currentFocus">release focus</span>
                 </div>
-                <div class="release-title" data-i18n="releases.currentTitle">Replace offset probing with sequential inference</div>
-                <div class="release-copy" data-i18n="releases.items.v0203">Replaces unreliable offset-based last-timestamp probing with sequential inference from next file's first timestamp, making time-window filtering reliable on files of any size.</div>
-                <a class="release-link" href="https://github.com/Fanduzi/BinlogVisualizer/blob/main/docs/releases/release-notes-v0.20.3.md" target="_blank" rel="noopener" data-i18n="releases.currentLink">Read release notes →</a>
+                <div class="release-title" data-i18n="releases.currentTitle">HTML file output and table operation breakdown</div>
+                <div class="release-copy" data-i18n="releases.items.v0210">Default HTML writes to a file instead of stdout, --output picks the destination, and Top Tables show INSERT/UPDATE/DELETE/DDL shares.</div>
+                <a class="release-link" href="https://github.com/Fanduzi/BinlogVisualizer/blob/main/docs/releases/release-notes-v0.21.0.md" target="_blank" rel="noopener" data-i18n="releases.currentLink">Read release notes →</a>
               </article>
 
               <div class="release-grid">
                 <article class="release-card">
                   <div class="release-card-head">
-                    <div class="release-card-version">v0.20.2</div>
-                    <div class="release-card-label" data-i18n="releases.labels.v0202">Probe regression fix</div>
+                    <div class="release-card-version">v0.20.3</div>
+                    <div class="release-card-label" data-i18n="releases.labels.v0203">Sequential inference</div>
                   </div>
-                  <div class="release-card-copy" data-i18n="releases.items.v0202">Fixes a regression that excluded all binlog files from time-windowed analysis on large files, and adds an explicit error when discovery resolves zero files.</div>
-                  <a class="release-card-link" href="https://github.com/Fanduzi/BinlogVisualizer/blob/main/docs/releases/release-notes-v0.20.2.md" target="_blank" rel="noopener" data-i18n="releases.links.v0202">Open v0.20.2 notes →</a>
+                  <div class="release-card-copy" data-i18n="releases.items.v0203">Replaces unreliable offset-based last-timestamp probing with sequential inference from next file's first timestamp, making time-window filtering reliable on files of any size.</div>
+                  <a class="release-card-link" href="https://github.com/Fanduzi/BinlogVisualizer/blob/main/docs/releases/release-notes-v0.20.3.md" target="_blank" rel="noopener" data-i18n="releases.links.v0203">Open v0.20.3 notes →</a>
                 </article>
                 <article class="release-card">
                   <div class="release-card-head">
@@ -1456,12 +1456,17 @@ install the binary, analyze one binlog, then move to ordered directory ranges an
               <div class="workflow-panel reveal">
                 <h3 data-i18n="install.quick.title">Quick start</h3>
                 <div class="code-block">
-                  <code data-i18n="install.quick.code"><span class="token-comment"># Homebrew</span>
+                  <code data-i18n="install.quick.code"><span class="token-comment"># macOS only (Homebrew cask)</span>
 <span class="token-prompt">$</span> <span class="token-command">brew tap</span> <span class="token-string">Fanduzi/binlogviz</span>
 <span class="token-prompt">$</span> <span class="token-command">brew install</span> <span class="token-string">--cask binlogviz</span>
 
-<span class="token-comment"># analyze one file</span>
-<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">mysql-bin.000123</span>
+<span class="token-comment"># Linux: install.sh or tarball</span>
+<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.21.0/install.sh</span>
+<span class="token-prompt">$</span> <span class="token-command">sh ./install.sh</span> <span class="token-flag">--version</span> <span class="token-string">v0.21.0</span>
+
+<span class="token-comment"># verify install with the sample ROW binlog</span>
+<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog</span>
+<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">minimal.binlog</span>
 
 <span class="token-comment"># save current + baseline snapshots, inspect them as JSON, then open a visual compare report</span>
 <span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-15T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-15T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>
@@ -1560,9 +1565,9 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             homeLabel: 'BinlogViz home'
           },
           hero: {
-            badge: 'v0.20.3 — replace offset probing with sequential inference',
+            badge: 'v0.21.0 — HTML file output and table operation breakdown',
             title: 'Turn MySQL ROW binlogs\ninto incident-ready reports',
-            sub: 'BinlogViz helps DBAs and on-call engineers move from raw binlog events to a readable workload story.\nFind hot tables, large transactions, write spikes, and incident-window changes, then save named baselines, compare current versus baseline, and hand the result to your team in a format they can actually use.',
+            sub: 'Fast ROW-binlog summary: hot tables, write shapes, before/after compare. A 510 MB file is typically a few seconds.\nSTATEMENT or MIXED files come back empty or undercounted. Printed positions are file evidence — use them as mysqlbinlog --start-position only when the span covers the transaction events, not an XID-only interval.',
             primary: 'Install BinlogViz',
             secondary: 'See output surfaces',
             code: '<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-15T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-15T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-14T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-14T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-previous</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-08T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-08T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz trend</span> <span class="token-flag">--from-snapshots</span> <span class="token-string">\'incident-*\'</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">trend.html</span>',
@@ -1664,9 +1669,10 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             sub: 'Keep the latest workflow release front and center, skim the last few product turns quickly, and use the archive link when you want the full history.',
             currentLabel: 'Current release',
             currentFocus: 'release focus',
-            currentTitle: 'Replace offset probing with sequential inference',
+            currentTitle: 'HTML file output and table operation breakdown',
             currentLink: 'Read release notes →',
             labels: {
+              v0203: 'Sequential inference',
               v0202: 'Probe regression fix',
               v0200: 'Fast discovery probing',
               v0181: 'Performance validation',
@@ -1674,6 +1680,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
               v0150: 'Trust boundary'
             },
             links: {
+              v0203: 'Open v0.20.3 notes →',
               v0202: 'Open v0.20.2 notes →',
               v0200: 'Open v0.20.0 notes →',
               v0181: 'Open v0.18.1 notes →',
@@ -1685,6 +1692,8 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             archiveDesc: 'Browse the full release history when you want older milestones, detailed changelogs, or download artifacts beyond the latest workflow surface.',
             archiveLink: 'View all release notes →',
             items: {
+              v0210: 'Default HTML writes to a file instead of stdout, --output picks the destination, and Top Tables show INSERT/UPDATE/DELETE/DDL shares.',
+              v0203: 'Replaces unreliable offset-based last-timestamp probing with sequential inference from next file\'s first timestamp, making time-window filtering reliable on files of any size.',
               v0202: 'Fixes a regression that excluded all binlog files from time-windowed analysis on large files, and adds an explicit error when discovery resolves zero files.',
               v0201: 'Offset-based timestamp probing now tolerates corrupted or truncated events gracefully, and HTML drill-down charts display Y-axis labels for clarity.',
               v0200: 'Discovery-mode probing now uses two-phase timestamp extraction instead of full file scans, and text report sparklines are downsampled to stay readable for multi-hour windows.',
@@ -1702,7 +1711,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             sub: 'The right onboarding path for a product site is simple and credible:\ninstall the binary, analyze one binlog, then move to ordered directory ranges and named snapshots when the incident story gets wide enough to compare against a baseline.',
             quick: {
               title: 'Quick start',
-              code: '<span class="token-comment"># Homebrew</span>\n<span class="token-prompt">$</span> <span class="token-command">brew tap</span> <span class="token-string">Fanduzi/binlogviz</span>\n<span class="token-prompt">$</span> <span class="token-command">brew install</span> <span class="token-string">--cask binlogviz</span>\n\n<span class="token-comment"># analyze one file</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">mysql-bin.000123</span>\n\n<span class="token-comment"># save current + baseline snapshots, inspect them as JSON, then open a visual compare report</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-15T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-15T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-08T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-08T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz snapshot</span> <span class="token-string">show</span> <span class="token-string">incident-current</span> <span class="token-flag">--format</span> <span class="token-string">json</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz compare</span> <span class="token-flag">--current-snapshot</span> <span class="token-string">incident-current</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">compare.html</span>'
+              code: '<span class="token-comment"># macOS only (Homebrew cask)</span>\n<span class="token-prompt">$</span> <span class="token-command">brew tap</span> <span class="token-string">Fanduzi/binlogviz</span>\n<span class="token-prompt">$</span> <span class="token-command">brew install</span> <span class="token-string">--cask binlogviz</span>\n\n<span class="token-comment"># Linux: install.sh or tarball</span>\n<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.21.0/install.sh</span>\n<span class="token-prompt">$</span> <span class="token-command">sh ./install.sh</span> <span class="token-flag">--version</span> <span class="token-string">v0.21.0</span>\n\n<span class="token-comment"># verify install with the sample ROW binlog</span>\n<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">minimal.binlog</span>\n\n<span class="token-comment"># save current + baseline snapshots, inspect them as JSON, then open a visual compare report</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-15T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-15T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-08T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-08T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz snapshot</span> <span class="token-string">show</span> <span class="token-string">incident-current</span> <span class="token-flag">--format</span> <span class="token-string">json</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz compare</span> <span class="token-flag">--current-snapshot</span> <span class="token-string">incident-current</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">compare.html</span>'
             },
             first: {
               title: 'What a good first session looks like',
@@ -1755,9 +1764,9 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             homeLabel: 'BinlogViz 首页'
           },
           hero: {
-            badge: 'v0.20.3 —— 用顺序推断替换 offset 末尾探测',
+            badge: 'v0.21.0 —— HTML 默认写文件与表操作分列',
             title: '把 MySQL ROW binlog\n变成可交付的事件报告',
-            sub: 'BinlogViz 帮助 DBA 和值班工程师把原始 binlog 事件转成可读的工作负载故事。\n定位热点表、大事务、写入尖峰和事故窗口变化，保存命名基线，然后对比 current 与 baseline，并以团队真正能消费的形式交付出去。',
+            sub: 'ROW binlog 的快速摘要：热表、写入形态、上线前后 compare。510 MB 级大约数秒。\nSTATEMENT / MIXED 会空或少计。报告位置是文件证据；只有跨度覆盖事务事件、而不是只有 XID 区间时，才当作 mysqlbinlog --start-position。',
             primary: '安装 BinlogViz',
             secondary: '查看输出形式',
             code: '<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-15T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-15T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-14T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-14T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-previous</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">2026-03-08T10:00:00Z</span> <span class="token-flag">--end</span> <span class="token-string">2026-03-08T10:30:00Z</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz trend</span> <span class="token-flag">--from-snapshots</span> <span class="token-string">\'incident-*\'</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">trend.html</span>',
@@ -1859,9 +1868,10 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             sub: '把最新 workflow 版本放在最前面，快速扫过最近几次产品转折；如果要看完整历史，再进归档入口。',
             currentLabel: '当前版本',
             currentFocus: 'release focus',
-            currentTitle: '用顺序推断替换 offset 末尾探测',
+            currentTitle: 'HTML 默认写文件与表操作分列',
             currentLink: '查看发布说明 →',
             labels: {
+              v0203: '顺序推断',
               v0202: 'Probe 回归修复',
               v0200: '快速发现探测',
               v0181: '性能验证',
@@ -1869,6 +1879,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
               v0150: '信任边界'
             },
             links: {
+              v0203: '打开 v0.20.3 说明 →',
               v0202: '打开 v0.20.2 说明 →',
               v0200: '打开 v0.20.0 说明 →',
               v0181: '打开 v0.18.1 说明 →',
@@ -1880,6 +1891,8 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             archiveDesc: '如果你想看更早的里程碑、更细的 changelog，或者下载最新 workflow surface 之外的历史产物，可以从这里进入完整发布历史。',
             archiveLink: '查看全部发布说明 →',
             items: {
+              v0210: 'HTML 默认写入文件而不是 stdout，可用 --output 指定路径；Top Tables 展示 INSERT/UPDATE/DELETE/DDL 占比。',
+              v0203: '用下一文件首个时间戳做顺序推断，替换不可靠的 offset 末尾探测，让任意大小文件的时间窗口过滤更可靠。',
               v0202: '修复了在大文件上将全部 binlog 文件排除在时间窗口分析之外的回归问题，并在发现阶段解析到零文件时给出明确报错。',
               v0201: '偏移量探测现在能优雅地容忍损坏或截断的事件，HTML 下钻图表显示 Y 轴标签提升可读性。',
               v0200: '发现模式探测改为两阶段时间戳提取，替代全文件扫描；文本报告 sparkline 降采样后保持多小时间隔下的可读性。',
@@ -1897,7 +1910,7 @@ Built for DBA investigation, incident review, and shareable reporting.</p>
             sub: '对产品官网来说，正确的上手路径应该简单且可信：\n安装二进制，分析一个 binlog，然后在事故故事变宽到需要基线对比时，再切到目录范围和命名快照。',
             quick: {
               title: '快速开始',
-              code: '<span class="token-comment"># Homebrew</span>\n<span class="token-prompt">$</span> <span class="token-command">brew tap</span> <span class="token-string">Fanduzi/binlogviz</span>\n<span class="token-prompt">$</span> <span class="token-command">brew install</span> <span class="token-string">--cask binlogviz</span>\n\n<span class="token-comment"># 分析一个文件</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">mysql-bin.000123</span>\n\n<span class="token-comment"># 保存 current + baseline 快照，查看 JSON 元数据，再打开 visual compare 报告</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-15T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-15T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-08T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-08T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz snapshot</span> <span class="token-string">show</span> <span class="token-string">incident-current</span> <span class="token-flag">--format</span> <span class="token-string">json</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz compare</span> <span class="token-flag">--current-snapshot</span> <span class="token-string">incident-current</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">compare.html</span>'
+              code: '<span class="token-comment"># 仅 macOS（Homebrew cask）</span>\n<span class="token-prompt">$</span> <span class="token-command">brew tap</span> <span class="token-string">Fanduzi/binlogviz</span>\n<span class="token-prompt">$</span> <span class="token-command">brew install</span> <span class="token-string">--cask binlogviz</span>\n\n<span class="token-comment"># Linux：install.sh 或 tarball</span>\n<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/v0.21.0/install.sh</span>\n<span class="token-prompt">$</span> <span class="token-command">sh ./install.sh</span> <span class="token-flag">--version</span> <span class="token-string">v0.21.0</span>\n\n<span class="token-comment"># 用样例 ROW binlog 验证安装</span>\n<span class="token-prompt">$</span> <span class="token-command">curl</span> <span class="token-string">-fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-string">minimal.binlog</span>\n\n<span class="token-comment"># 保存 current + baseline 快照，查看 JSON 元数据，再打开 visual compare 报告</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-15T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-15T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">incident-current</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz analyze</span> <span class="token-flag">--from-dir</span> <span class="token-string">/var/lib/mysql</span> <span class="token-flag">--prefix</span> <span class="token-string">mysql-bin.</span> <span class="token-flag">--start</span> <span class="token-string">"2026-03-08T10:00:00Z"</span> <span class="token-flag">--end</span> <span class="token-string">"2026-03-08T10:30:00Z"</span> <span class="token-flag">--format</span> <span class="token-string">json</span> <span class="token-flag">--snapshot-name</span> <span class="token-string">baseline-weekly-orders</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz snapshot</span> <span class="token-string">show</span> <span class="token-string">incident-current</span> <span class="token-flag">--format</span> <span class="token-string">json</span>\n<span class="token-prompt">$</span> <span class="token-command">binlogviz compare</span> <span class="token-flag">--current-snapshot</span> <span class="token-string">incident-current</span> <span class="token-flag">--baseline-snapshot</span> <span class="token-string">baseline-weekly-orders</span> <span class="token-flag">--format</span> <span class="token-string">html</span> &gt; <span class="token-string">compare.html</span>'
             },
             first: {
               title: '一个好的首轮会话应该长这样',

--- a/docs/recipe/analyze-local-binlogs.md
+++ b/docs/recipe/analyze-local-binlogs.md
@@ -4,7 +4,14 @@ This guide focuses on practical DBA workflows for running `binlogviz analyze` ag
 
 ## Start with One File
 
-When you want the fastest confidence check, start with a single file:
+When you want the fastest confidence check, start with the sample ROW binlog:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
+```
+
+Then point the same command at one of your files:
 
 ```bash
 binlogviz analyze mysql-bin.000123

--- a/docs/recipe/analyze-local-binlogs.zh-CN.md
+++ b/docs/recipe/analyze-local-binlogs.zh-CN.md
@@ -4,7 +4,14 @@
 
 ## 先从一个文件开始
 
-如果你希望用最快路径建立信心，先从单个文件开始：
+如果你希望用最快路径建立信心，先用样例 ROW binlog：
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
+```
+
+然后再对你自己的文件跑同一条命令：
 
 ```bash
 binlogviz analyze mysql-bin.000123

--- a/docs/recipe/quickstart.md
+++ b/docs/recipe/quickstart.md
@@ -2,6 +2,10 @@
 
 This guide is the shortest path from installation to a useful `binlogviz analyze` run.
 
+**What it is:** a fast ROW-binlog summary — hot tables, write shapes, before/after compare. A 510 MB file is typically a few seconds.
+
+**What it is not:** a STATEMENT/MIXED full-file analyzer (those runs come back empty or undercounted). Printed positions are file evidence; use them as `mysqlbinlog --start-position` only when the span covers the transaction events, not an XID-only interval.
+
 ## 1. Install or Verify BinlogViz
 
 Use a release artifact if you want a tagged binary, or build from source if you are working locally.
@@ -20,11 +24,14 @@ binlogviz version
 
 ## 2. Validate One File First
 
-Start with one local `ROW` binlog file:
+Start with the downloadable sample ROW binlog (1500 bytes, in-repo fixture):
 
 ```bash
-binlogviz analyze mysql-bin.000123
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
 ```
+
+From a source checkout you can also run `binlogviz analyze cmd/binlogviz/testdata/minimal.binlog`.
 
 This is the fastest way to confirm:
 

--- a/docs/recipe/quickstart.zh-CN.md
+++ b/docs/recipe/quickstart.zh-CN.md
@@ -2,6 +2,10 @@
 
 本指南提供从安装到第一次拿到有价值 `binlogviz analyze` 结果的最短路径。
 
+**适用：** ROW binlog 的热表摘要、写入形态、上线前后 compare。510 MB 级大约数秒。
+
+**不适用：** STATEMENT / 默认 MIXED（会空或只统计 ROW 子集）。报告位置是文件证据；只有跨度覆盖事务事件、而不是只有 XID 区间时，才当作 `mysqlbinlog --start-position`。
+
 ## 1. 安装或验证 BinlogViz
 
 如果你需要带发布版本号的二进制，优先使用 release artifact；如果你是在本地开发或验证，也可以直接从源码构建。
@@ -20,11 +24,14 @@ binlogviz version
 
 ## 2. 先用一个文件验证分析链路
 
-从一个本地 `ROW` binlog 文件开始：
+先下载仓库里的样例 ROW binlog（1500 字节）：
 
 ```bash
-binlogviz analyze mysql-bin.000123
+curl -fsSLO https://raw.githubusercontent.com/Fanduzi/BinlogVisualizer/main/cmd/binlogviz/testdata/minimal.binlog
+binlogviz analyze minimal.binlog
 ```
+
+如果已经 clone 了仓库，也可以直接 `binlogviz analyze cmd/binlogviz/testdata/minimal.binlog`。
 
 这是最快能确认以下几点的方式：
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -95,6 +95,11 @@ For the exact discovery matching, ordering, resolved-file reporting, and invalid
 | `--sql-context` | `summary` | SQL context presentation mode: `summary`, `off`, or `full`. |
 | `--top-tables` | `10` | Number of top tables to include in the report. |
 | `--top-transactions` | `10` | Number of top transactions to include in the report. |
+| `--top` | `10` | Default number of ranked items for text detail sections (minutes, patterns). |
+| `--details` | `false` | Show minute details and write-shape patterns in the text report. |
+| `--show-minutes` | `false` | Show minute-level activity in the text report. |
+| `--show-patterns` | `false` | Show write-shape patterns in the text report. |
+| `--detail-store` | `none` | Optional transaction detail backend: `none` or `duckdb`. |
 | `--detect-spikes` | `false` | Enable write spike detection. |
 | `--large-trx-rows` | `1000` | Row threshold for large transaction alerts. |
 | `--large-trx-duration` | `30s` | Duration threshold for large transaction alerts. |
@@ -126,6 +131,12 @@ Rules:
 - the save confirmation is written to `stderr`
 
 If `--snapshot-dir` is omitted, BinlogViz saves to `~/.binlogviz/snapshots/<name>.json`.
+
+Detail flags for the text report:
+
+```bash
+binlogviz analyze mysql-bin.000123 --details --show-minutes --show-patterns
+```
 
 ## `compare` Command Syntax
 

--- a/docs/reference/cli.zh-CN.md
+++ b/docs/reference/cli.zh-CN.md
@@ -95,6 +95,11 @@ binlogviz analyze --from-dir /var/lib/mysql --prefix mysql-bin.
 | `--sql-context` | `summary` | SQL 上下文展示模式：`summary`、`off` 或 `full`。 |
 | `--top-tables` | `10` | 报告中包含的 Top 表数量。 |
 | `--top-transactions` | `10` | 报告中包含的 Top 事务数量。 |
+| `--top` | `10` | 文本明细章节（分钟、写入形态）的默认 Top-N。 |
+| `--details` | `false` | 在文本报告中同时展开分钟明细和写入形态。 |
+| `--show-minutes` | `false` | 在文本报告中展示分钟级活动。 |
+| `--show-patterns` | `false` | 在文本报告中展示写入形态。 |
+| `--detail-store` | `none` | 可选事务明细后端：`none` 或 `duckdb`。 |
 | `--detect-spikes` | `false` | 启用写入尖峰检测。 |
 | `--large-trx-rows` | `1000` | 大事务告警的行数阈值。 |
 | `--large-trx-duration` | `30s` | 大事务告警的持续时间阈值。 |
@@ -126,6 +131,12 @@ binlogviz analyze --from-dir /var/lib/mysql --prefix mysql-bin. \
 - 保存成功提示写到 `stderr`
 
 如果省略 `--snapshot-dir`，BinlogViz 会保存到 `~/.binlogviz/snapshots/<name>.json`。
+
+文本报告明细参数示例：
+
+```bash
+binlogviz analyze mysql-bin.000123 --details --show-minutes --show-patterns
+```
 
 ## `compare` 命令语法
 

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$VERSION" ]; then
-  echo "--version is required, for example: ./install.sh --version v0.18.1" >&2
+  echo "--version is required, for example: ./install.sh --version v0.21.0" >&2
   exit 1
 fi
 

--- a/internal/analyzer/README.md
+++ b/internal/analyzer/README.md
@@ -13,7 +13,7 @@
 | `alerts.go` | Builds large transaction alerts from completed transactions. |
 | `spikes.go` | Detects overall and table-level spike alerts from minute buckets. |
 | `diagnostics.go` | Builds DBA-oriented findings with alert-referenced-only transaction indexing, bounded top-N transaction/minute rankings, hot intervals, and file throughput segments. Internal helpers are indexed lookups only; legacy linear scans have been removed. |
-| `pattern_drilldowns.go` | Selects high-signal pattern drilldown candidates with bounded top-N representative transaction selection using bounded insertion sort instead of full-slice copy. |
+| `pattern_drilldowns.go` | Selects high-signal pattern drilldown candidates. Representative transactions must share the pattern identity (table set + ops + shape); sub-1% shares stay visible. |
 | `report_aggregator.go` | Maintains bounded streaming state for report assembly so default analyze output does not require full transaction rehydration. Tracks operation counts for timeseries, alert-referenced transactions for evidence, and txn-size histograms. |
 | `detail_store.go` | Defines optional detail persistence backends. The default mode is `none`; DuckDB remains available for explicit detail storage. |
 | `*_test.go` | Verifies analyzer behavior, boundary handling, window filtering, and benchmark coverage. |

--- a/internal/analyzer/diagnostics_test.go
+++ b/internal/analyzer/diagnostics_test.go
@@ -457,8 +457,9 @@ func BenchmarkSelectRepresentativeTxnsLargeInput(b *testing.B) {
 		}
 	}
 	b.ReportAllocs()
+	patternKey, _ := patternIdentity(txns[0])
 	for i := 0; i < b.N; i++ {
-		result := selectRepresentativeTxns(txns, "", 2)
+		result := selectRepresentativeTxns(txns, patternKey, 2)
 		if len(result) != 2 {
 			b.Fatalf("expected 2 representative txns, got %d", len(result))
 		}

--- a/internal/analyzer/pattern_drilldowns.go
+++ b/internal/analyzer/pattern_drilldowns.go
@@ -168,8 +168,8 @@ func buildDrilldown(c candidate, minutes []model.MinuteBucket, txns []model.Tran
 func formatWhySelected(c candidate) string {
 	parts := make([]string, 0, 2)
 	if c.dominance {
-		parts = append(parts, fmt.Sprintf("dominates workload (%.0f%% rows, %.0f%% txns)",
-			c.pattern.ShareOfRows*100, c.pattern.ShareOfTransactions*100))
+		parts = append(parts, fmt.Sprintf("dominates workload (%s rows, %s txns)",
+			formatSharePercent(c.pattern.ShareOfRows), formatSharePercent(c.pattern.ShareOfTransactions)))
 	}
 	if c.anomaly {
 		parts = append(parts, "anomalous concentration or spike alignment")
@@ -186,6 +186,18 @@ func joinWhy(parts []string) string {
 		result += " + " + parts[i]
 	}
 	return result
+}
+
+// formatSharePercent keeps sub-1% shares visible instead of rounding 0.3% to 0%.
+func formatSharePercent(share float64) string {
+	pct := share * 100
+	if pct <= 0 {
+		return "0%"
+	}
+	if pct < 1 {
+		return fmt.Sprintf("%.1f%%", pct)
+	}
+	return fmt.Sprintf("%.0f%%", pct)
 }
 
 // computeMeanRowsPerTxn calculates the average avg_rows_per_txn across all patterns.
@@ -299,14 +311,25 @@ func selectPeakMinutes(minutes []model.MinuteBucket, n int) []model.PatternPeakM
 	return result
 }
 
-// selectRepresentativeTxns returns up to N transactions sorted by TotalRows descending.
-// patternKey is used for future pattern-txn matching; currently selects from all txns.
-func selectRepresentativeTxns(txns []model.Transaction, _ string, n int) []model.PatternRepresentativeTxn {
-	if len(txns) == 0 || n <= 0 {
+// selectRepresentativeTxns returns up to N transactions that belong to patternKey
+// (same table set + ops + shape), sorted by TotalRows descending.
+func selectRepresentativeTxns(txns []model.Transaction, patternKey string, n int) []model.PatternRepresentativeTxn {
+	if len(txns) == 0 || n <= 0 || patternKey == "" {
 		return nil
 	}
 
-	top := topTransactions(txns, n, func(left, right model.Transaction) bool {
+	matched := make([]model.Transaction, 0, len(txns))
+	for _, txn := range txns {
+		key, _ := patternIdentity(txn)
+		if key == patternKey {
+			matched = append(matched, txn)
+		}
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+
+	top := topTransactions(matched, n, func(left, right model.Transaction) bool {
 		if left.TotalRows != right.TotalRows {
 			return left.TotalRows > right.TotalRows
 		}

--- a/internal/analyzer/pattern_drilldowns_test.go
+++ b/internal/analyzer/pattern_drilldowns_test.go
@@ -166,11 +166,12 @@ func TestBuildPatternDrilldowns_NestedCaps(t *testing.T) {
 		{Minute: ts(10, 3), TotalRows: 5000, TxnCount: 5},
 	}
 	txns := []model.Transaction{
-		{TxnKey: "t1", TotalRows: 800, Tables: map[string]int{"a": 800}},
-		{TxnKey: "t2", TotalRows: 780, Tables: map[string]int{"a": 780}},
-		{TxnKey: "t3", TotalRows: 760, Tables: map[string]int{"a": 760}},
-		{TxnKey: "t4", TotalRows: 750, Tables: map[string]int{"a": 750}},
+		{TxnKey: "t1", TotalRows: 800, EventCount: 1, Tables: map[string]int{"a": 800}, Operations: map[string]int{"INSERT": 800}},
+		{TxnKey: "t2", TotalRows: 780, EventCount: 1, Tables: map[string]int{"a": 780}, Operations: map[string]int{"INSERT": 780}},
+		{TxnKey: "t3", TotalRows: 760, EventCount: 1, Tables: map[string]int{"a": 760}, Operations: map[string]int{"INSERT": 760}},
+		{TxnKey: "t4", TotalRows: 750, EventCount: 1, Tables: map[string]int{"a": 750}, Operations: map[string]int{"INSERT": 750}},
 	}
+	patterns[0].PatternKey, _ = patternIdentity(txns[0])
 	alerts := []model.Alert{}
 
 	result := BuildPatternDrilldowns(patterns, minutes, txns, alerts)
@@ -281,5 +282,70 @@ func TestBuildPatternDrilldowns_GlobalSpikeDoesNotFlagUnrelatedPattern(t *testin
 	}
 	if !foundP2 {
 		t.Error("expected p2 to be selected for dominance")
+	}
+}
+
+func TestSelectRepresentativeTxnsBelongToSamePattern(t *testing.T) {
+	insertLarge := model.Transaction{
+		TxnKey:     "txn-1",
+		TotalRows:  400000,
+		EventCount: 1,
+		Tables:     map[string]int{"dogfood_big.t": 400000},
+		Operations: map[string]int{"INSERT": 400000},
+	}
+	insertLarge2 := model.Transaction{
+		TxnKey:     "txn-2",
+		TotalRows:  400000,
+		EventCount: 1,
+		Tables:     map[string]int{"dogfood_big.t": 400000},
+		Operations: map[string]int{"INSERT": 400000},
+	}
+	deleteLarge := model.Transaction{
+		TxnKey:     "txn-del-1",
+		TotalRows:  80,
+		EventCount: 1,
+		Tables:     map[string]int{"dogfood_big.t": 80},
+		Operations: map[string]int{"DELETE": 80},
+	}
+	deleteLarge2 := model.Transaction{
+		TxnKey:     "txn-del-2",
+		TotalRows:  60,
+		EventCount: 1,
+		Tables:     map[string]int{"dogfood_big.t": 60},
+		Operations: map[string]int{"DELETE": 60},
+	}
+	deleteKey, _ := patternIdentity(deleteLarge)
+	insertKey, _ := patternIdentity(insertLarge)
+	if deleteKey == insertKey {
+		t.Fatal("expected INSERT and DELETE large-batch identities to differ")
+	}
+
+	got := selectRepresentativeTxns(
+		[]model.Transaction{insertLarge, insertLarge2, deleteLarge, deleteLarge2},
+		deleteKey,
+		2,
+	)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 DELETE representatives, got %d", len(got))
+	}
+	for _, txn := range got {
+		if txn.TxnKey == "txn-1" || txn.TxnKey == "txn-2" {
+			t.Fatalf("DELETE pattern cited INSERT txn %s", txn.TxnKey)
+		}
+		if txn.TotalRows >= 400000 {
+			t.Fatalf("DELETE representative has INSERT-sized rows=%d", txn.TotalRows)
+		}
+	}
+}
+
+func TestFormatSharePercentKeepsSubOnePercent(t *testing.T) {
+	if got := formatSharePercent(0.003); got != "0.3%" {
+		t.Fatalf("0.3%% share formatted as %q, want 0.3%%", got)
+	}
+	if got := formatSharePercent(0.66); got != "66%" {
+		t.Fatalf("66%% share formatted as %q, want 66%%", got)
+	}
+	if got := formatSharePercent(0); got != "0%" {
+		t.Fatalf("zero share formatted as %q, want 0%%", got)
 	}
 }

--- a/internal/analyzer/report_aggregator.go
+++ b/internal/analyzer/report_aggregator.go
@@ -49,6 +49,7 @@ type ReportAggregator struct {
 	fileCoverage        model.FileCoverage
 	patterns            map[string]*model.PatternStats
 	patternOrder        []string
+	patternRepTxns      map[string][]model.Transaction
 	txnSize             txnSizeTracker
 	operationCounts     map[time.Time]operationMinuteStats
 }
@@ -99,6 +100,7 @@ func NewReportAggregator(opts Options) *ReportAggregator {
 	return &ReportAggregator{
 		opts:                opts,
 		patterns:            make(map[string]*model.PatternStats),
+		patternRepTxns:      make(map[string][]model.Transaction),
 		txnSize:             newTxnSizeTracker(),
 		operationCounts:     make(map[time.Time]operationMinuteStats),
 		alertReferencedTxns: make(map[string]model.Transaction),
@@ -215,6 +217,7 @@ func (a *ReportAggregator) Snapshot() ReportSnapshot {
 
 	// Merge largest + alert-referenced transactions into a single evidence pool.
 	evidenceTxns := mergeEvidenceTransactions(a.largest, a.alertReferencedTxns)
+	drilldownTxns := mergeEvidenceTransactions(evidenceTxns, flattenPatternRepTxns(a.patternRepTxns))
 
 	diagnostics := model.Diagnostics{
 		FileCoverage:        a.fileCoverage,
@@ -242,7 +245,7 @@ func (a *ReportAggregator) Snapshot() ReportSnapshot {
 		Diagnostics:       diagnostics,
 		Alerts:            alerts,
 		Warnings:          a.warnings,
-		PatternDrilldowns: BuildPatternDrilldowns(patterns, minutes, evidenceTxns, alerts),
+		PatternDrilldowns: BuildPatternDrilldowns(patterns, minutes, drilldownTxns, alerts),
 	}
 }
 
@@ -272,6 +275,21 @@ func insertTopTransaction(current []model.Transaction, txn model.Transaction, li
 		current = current[:limit]
 	}
 	return current
+}
+
+func flattenPatternRepTxns(byPattern map[string][]model.Transaction) map[string]model.Transaction {
+	if len(byPattern) == 0 {
+		return nil
+	}
+	out := make(map[string]model.Transaction)
+	for _, txns := range byPattern {
+		for _, txn := range txns {
+			if txn.TxnKey != "" {
+				out[txn.TxnKey] = txn
+			}
+		}
+	}
+	return out
 }
 
 func mergeEvidenceTransactions(largest []model.Transaction, alertReferenced map[string]model.Transaction) []model.Transaction {
@@ -360,6 +378,7 @@ func (a *ReportAggregator) consumePattern(txn model.Transaction) {
 	if p.SampleQuerySummary == "" && strings.TrimSpace(txn.QuerySummary) != "" {
 		p.SampleQuerySummary = txn.QuerySummary
 	}
+	a.patternRepTxns[key] = insertTopTransaction(a.patternRepTxns[key], txn, maxRepresentativeTxns, transactionRowsBetter)
 }
 
 func (a *ReportAggregator) snapshotPatterns() []model.PatternStats {

--- a/internal/analyzer/report_aggregator_test.go
+++ b/internal/analyzer/report_aggregator_test.go
@@ -7,6 +7,7 @@ package analyzer
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,70 @@ func TestReportAggregatorDoesNotRetainAllTransactions(t *testing.T) {
 	}
 	if len(snapshot.Diagnostics.LargestTransactions) > 5 {
 		t.Fatalf("largest transactions retained %d, want <= 5", len(snapshot.Diagnostics.LargestTransactions))
+	}
+	for _, reps := range agg.patternRepTxns {
+		if len(reps) > maxRepresentativeTxns {
+			t.Fatalf("pattern reps retained %d, want <= %d", len(reps), maxRepresentativeTxns)
+		}
+	}
+}
+
+func TestReportAggregatorDeletePatternDoesNotCiteInsertTxns(t *testing.T) {
+	agg := NewReportAggregator(DefaultOptions())
+	base := time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		agg.ConsumeTransaction(model.Transaction{
+			TxnKey:     fmt.Sprintf("txn-insert-%d", i+1),
+			StartTime:  base,
+			EndTime:    base,
+			TotalRows:  400000,
+			EventCount: 1,
+			Tables:     map[string]int{"dogfood_big.t": 400000},
+			Operations: map[string]int{"INSERT": 400000},
+		})
+	}
+	for i := 0; i < 20; i++ {
+		agg.ConsumeTransaction(model.Transaction{
+			TxnKey:     fmt.Sprintf("txn-del-%d", i+1),
+			StartTime:  base,
+			EndTime:    base,
+			TotalRows:  80 - i,
+			EventCount: 1,
+			Tables:     map[string]int{"dogfood_big.t": 80 - i},
+			Operations: map[string]int{"DELETE": 80 - i},
+		})
+	}
+
+	snapshot := agg.Snapshot()
+	var deleteKey string
+	for _, p := range snapshot.Patterns {
+		if _, ok := p.Operations["DELETE"]; ok && p.Operations["INSERT"] == 0 {
+			deleteKey = p.PatternKey
+			if got := formatSharePercent(p.ShareOfTransactions); got == "0%" && p.ShareOfTransactions > 0 {
+				t.Fatalf("DELETE txn share %f formatted as 0%%", p.ShareOfTransactions)
+			}
+		}
+	}
+	if deleteKey == "" {
+		t.Fatal("expected a DELETE-only pattern")
+	}
+	foundDelete := false
+	for _, d := range snapshot.PatternDrilldowns {
+		if d.PatternKey != deleteKey {
+			continue
+		}
+		foundDelete = true
+		if len(d.RepresentativeTransactions) == 0 {
+			t.Fatal("DELETE pattern had no representative transactions")
+		}
+		for _, txn := range d.RepresentativeTransactions {
+			if txn.TotalRows >= 400000 || strings.HasPrefix(txn.TxnKey, "txn-insert-") {
+				t.Fatalf("DELETE pattern cited INSERT txn %s rows=%d", txn.TxnKey, txn.TotalRows)
+			}
+		}
+	}
+	if !foundDelete {
+		t.Fatal("expected DELETE pattern to be selected for drilldown")
 	}
 }
 

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -231,6 +231,22 @@
     "description": "Total rows label",
     "other": "Total Rows"
   },
+  "report.label.logicalRows": {
+    "description": "Logical row-image count label",
+    "other": "Logical Rows"
+  },
+  "report.label.format": {
+    "description": "Input format label",
+    "other": "Format"
+  },
+  "report.text.rowImageSummary": {
+    "description": "Default text report format boundary",
+    "other": "ROW images / logical rows (STATEMENT/MIXED Query-DML is not counted)"
+  },
+  "report.label.largestTxnBytes": {
+    "description": "Largest transaction byte size label",
+    "other": "Largest txn"
+  },
   "report.label.totalEvents": {
     "description": "Total events label",
     "other": "Total Events"

--- a/internal/i18n/locales/zh-CN.json
+++ b/internal/i18n/locales/zh-CN.json
@@ -231,6 +231,22 @@
     "description": "行数总数标签",
     "other": "行数总数"
   },
+  "report.label.logicalRows": {
+    "description": "逻辑行（ROW image）计数标签",
+    "other": "逻辑行"
+  },
+  "report.label.format": {
+    "description": "输入格式标签",
+    "other": "格式"
+  },
+  "report.text.rowImageSummary": {
+    "description": "默认文本报告格式边界",
+    "other": "ROW 镜像 / 逻辑行（STATEMENT/MIXED 的 Query-DML 不计入）"
+  },
+  "report.label.largestTxnBytes": {
+    "description": "最大事务字节标签",
+    "other": "最大事务"
+  },
   "report.label.totalEvents": {
     "description": "事件总数标签",
     "other": "事件总数"

--- a/internal/report/README.md
+++ b/internal/report/README.md
@@ -39,7 +39,7 @@ Analyze report renderers for text, JSON, Markdown, and HTML output.
 - `off` omits query lines in text and omits all query-related JSON fields.
 - `full` only exposes bounded SQL from `QueryContext.SQL`; it never reconstructs or emits unbounded original SQL.
 - `product.go` owns presentation defaults such as `DefaultTopN` so text, HTML, and command flags share one report contract.
-- The default text report is diagnostic-first: summary, top findings, top tables, and next actions. Minute activity and write-shape patterns require explicit detail options.
+- The default text report is an incident brief: summary, hot tables, and largest transactions first; findings and activity come after. Minute activity and write-shape patterns require explicit detail options.
 - Text Top Findings are the same `diagnostics.findings` / `alerts` as JSON. Hot intervals and longest transactions are evidence only; they are not synthesized into critical/warning findings.
 - The text Top Tables report sizes its table-name column to the widest displayed name; `Affected Rows` covers INSERT/UPDATE/DELETE rows and `Row Share` is that table's portion of all affected rows.
 - Text rendering is intentionally kept on a fast path: it must not build HTML chart data, read embedded ECharts assets, or render pattern drilldowns unless detail options request them.

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -1,6 +1,6 @@
 // Package report renders human-readable text reports from bounded analysis results.
 // input: analyzer-produced AnalysisResult values plus optional SQL context presentation controls.
-// output: concise diagnostic-first text reports with opt-in minute and write-pattern detail sections.
+// output: incident-brief text reports (hot tables and largest txns first) with opt-in minute and write-pattern detail sections.
 // pos: text renderer for the CLI output path after analyzer Finalize.
 // note: if this file changes, update this header and module README.md.
 package report
@@ -39,10 +39,10 @@ func RenderTextWithOptions(result model.AnalysisResult, opts Options) (string, e
 	var buf strings.Builder
 
 	renderDiagnosticSummary(&buf, result)
-	renderTopFindings(&buf, result, opts)
-	renderActivitySection(&buf, result)
 	renderTopTablesTable(&buf, result.Tables, opts.TopN)
 	renderTopTransactions(&buf, result, opts.TopN)
+	renderTopFindings(&buf, result, opts)
+	renderActivitySection(&buf, result)
 	renderNextActions(&buf, result)
 
 	if opts.ShowMinutes {
@@ -59,10 +59,14 @@ func renderDiagnosticSummary(buf *strings.Builder, result model.AnalysisResult) 
 	summary := result.Summary
 	buf.WriteString("=== " + i18n.T("report.text.summary") + " ===\n")
 	buf.WriteString(fmt.Sprintf("  %s: %s - %s\n", i18n.T("report.label.timeRange"), formatTime(summary.StartTime), formatTime(summary.EndTime)))
+	buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.label.format"), i18n.T("report.text.rowImageSummary")))
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalTransactions"), summary.TotalTransactions))
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalRows"), summary.TotalRows))
 	buf.WriteString(fmt.Sprintf("  %s: %d\n", i18n.T("report.label.totalEvents"), summary.TotalEvents))
 	buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.html.analyze.ddlTimeline"), formatDDLTimelineSummary(result.Diagnostics.DDLEvents)))
+	if bytes := largestTxnBytes(result); bytes > 0 {
+		buf.WriteString(fmt.Sprintf("  %s: %s\n", i18n.T("report.label.largestTxnBytes"), formatByteSize(bytes)))
+	}
 	buf.WriteString("\n")
 }
 
@@ -208,23 +212,31 @@ func maxInt(a, b int) int {
 func renderTopTransactions(buf *strings.Builder, result model.AnalysisResult, topN int) {
 	buf.WriteString("=== " + i18n.T("report.text.topTransactions") + " ===\n")
 
-	limit := minInt(1, topN)
-	lines := make([]string, 0, limit*3)
-	for _, txn := range limitTransactions(result.Diagnostics.LargestTransactions, limit) {
-		lines = append(lines, fmt.Sprintf("  %s: %s rows=%d tables=%d file=%s",
-			i18n.T("report.text.largestTransaction"), txn.TxnKey, txn.TotalRows, len(txn.Tables), formatTxnEvidenceLocation(txn)))
+	largestLimit := minInt(3, topN)
+	otherLimit := minInt(1, topN)
+	lines := make([]string, 0, largestLimit+otherLimit*2)
+	for _, txn := range limitTransactions(result.Diagnostics.LargestTransactions, largestLimit) {
+		line := fmt.Sprintf("  %s: %s rows=%d tables=%d file=%s",
+			i18n.T("report.text.largestTransaction"), txn.TxnKey, txn.TotalRows, len(txn.Tables), formatTxnEvidenceLocation(txn))
+		if table := dominantTableName(txn.Tables); table != "" {
+			line += " table=" + table
+		}
+		if txn.BinlogBytes > 0 {
+			line += " bytes=" + formatByteSize(txn.BinlogBytes)
+		}
+		lines = append(lines, line)
 		if cmd := mysqlbinlogCmd(txn); cmd != "" {
 			lines = append(lines, "    "+cmd)
 		}
 	}
-	for _, txn := range limitTransactions(result.Diagnostics.LongestTransactions, limit) {
+	for _, txn := range limitTransactions(result.Diagnostics.LongestTransactions, otherLimit) {
 		lines = append(lines, fmt.Sprintf("  %s: %s dur=%s rows=%d file=%s",
 			i18n.T("report.text.longestTransaction"), txn.TxnKey, formatDuration(txn.Duration), txn.TotalRows, formatSuspiciousLocation(txn)))
 		if cmd := mysqlbinlogCmd(txn); cmd != "" {
 			lines = append(lines, "    "+cmd)
 		}
 	}
-	for _, txn := range limitTransactions(result.Diagnostics.WidestTransactions, limit) {
+	for _, txn := range limitTransactions(result.Diagnostics.WidestTransactions, otherLimit) {
 		lines = append(lines, fmt.Sprintf("  %s: %s tables=%d rows=%d file=%s",
 			i18n.T("report.text.widestTransaction"), txn.TxnKey, len(txn.Tables), txn.TotalRows, formatSuspiciousLocation(txn)))
 		if cmd := mysqlbinlogCmd(txn); cmd != "" {
@@ -434,6 +446,40 @@ func firstSuspiciousLocation(result model.AnalysisResult) string {
 		return formatBinlogLocation(ddl.BinlogPath, ddl.PositionStart, ddl.PositionEnd)
 	}
 	return ""
+}
+
+func largestTxnBytes(result model.AnalysisResult) int64 {
+	var maxBytes int64
+	for _, txn := range result.Diagnostics.LargestTransactions {
+		if txn.BinlogBytes > maxBytes {
+			maxBytes = txn.BinlogBytes
+		}
+	}
+	return maxBytes
+}
+
+func dominantTableName(tables map[string]int) string {
+	best := ""
+	bestRows := -1
+	for name, rows := range tables {
+		if rows > bestRows || (rows == bestRows && (best == "" || name < best)) {
+			best = name
+			bestRows = rows
+		}
+	}
+	return best
+}
+
+func formatByteSize(n int64) string {
+	const kb = 1024
+	switch {
+	case n < kb:
+		return fmt.Sprintf("%dB", n)
+	case n < kb*kb:
+		return fmt.Sprintf("%.1fKB", float64(n)/float64(kb))
+	default:
+		return fmt.Sprintf("%.1fMB", float64(n)/float64(kb*kb))
+	}
 }
 
 func formatSuspiciousLocation(txn model.Transaction) string {

--- a/internal/report/text_test.go
+++ b/internal/report/text_test.go
@@ -1,4 +1,4 @@
-// Package report verifies concise diagnostic text rendering and opt-in detail sections.
+// Package report verifies incident-brief text rendering and opt-in detail sections.
 // input: synthetic AnalysisResult fixtures with summary, table, minute, pattern, and diagnostic evidence.
 // output: regression coverage for default diagnostic sections, table limits, and detail flags.
 // pos: text renderer regression suite guarding user-facing CLI report formatting.
@@ -77,6 +77,27 @@ func TestRenderTextTopFindingsUseSameAlertsAsJSON(t *testing.T) {
 	}
 	if strings.Contains(out, "[critical] Write spike") {
 		t.Fatalf("text findings should not invent a critical severity:\n%s", out)
+	}
+}
+
+func TestRenderTextIncidentBriefPutsTablesAndTxnsBeforeFindings(t *testing.T) {
+	result := productTextFixture()
+	out, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tables := strings.Index(out, "=== Top Tables ===")
+	txns := strings.Index(out, "=== Top Transactions ===")
+	findings := strings.Index(out, "=== Top Findings ===")
+	if tables < 0 || txns < 0 || findings < 0 {
+		t.Fatalf("missing incident-brief sections\n%s", out)
+	}
+	if !(tables < txns && txns < findings) {
+		t.Fatalf("expected tables then txns then findings, got tables=%d txns=%d findings=%d\n%s", tables, txns, findings, out)
+	}
+	if !strings.Contains(out, "ROW images / logical rows") {
+		t.Fatalf("expected ROW/logical-row capability line in summary\n%s", out)
 	}
 }
 
@@ -346,6 +367,29 @@ func TestRenderTextTopTransactionsUsesTopLimit(t *testing.T) {
 		if strings.Contains(out, token) {
 			t.Fatalf("expected top limit to hide token %q\n%s", token, out)
 		}
+	}
+}
+
+func TestRenderTextShowsUpToThreeLargestTransactions(t *testing.T) {
+	result := productTextFixture()
+	result.Diagnostics.LargestTransactions = []model.Transaction{
+		{TxnKey: "txn-largest-a", TotalRows: 5000, BinlogBytes: 4096, Tables: map[string]int{"shop.orders": 5000}},
+		{TxnKey: "txn-largest-b", TotalRows: 4000, Tables: map[string]int{"shop.users": 4000}},
+		{TxnKey: "txn-largest-c", TotalRows: 3000, Tables: map[string]int{"shop.payments": 3000}},
+		{TxnKey: "txn-largest-d", TotalRows: 2000, Tables: map[string]int{"shop.audit": 2000}},
+	}
+
+	out, err := RenderText(result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, token := range []string{"txn-largest-a", "txn-largest-b", "txn-largest-c", "table=shop.orders", "Largest txn: 4.0KB"} {
+		if !strings.Contains(out, token) {
+			t.Fatalf("expected token %q\n%s", token, out)
+		}
+	}
+	if strings.Contains(out, "txn-largest-d") {
+		t.Fatalf("expected fourth largest txn to stay hidden\n%s", out)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes operator/docs/report dogfood issues #4, #10, #11, #20, #21, and #22 in one PR.

Does **not** rewrite the HTML incident page in #17 (still spike-first there). Does not touch compare/trend (#28), STATEMENT/MIXED exit behavior (#27), or txn-span / `mysqlbinlog` command generation (#29).

## Investigation

- **#4** is right. Site source lives in this repo at `docs/landing/index.html` (Cloudflare Pages is configured elsewhere). Badge/Releases were still `v0.20.3`; latest GitHub release is `v0.21.0`. Quick start led with brew cask. `install.sh` missing `--version` still said `v0.18.1`.
- **#10 / #22** are right. First command `analyze mysql-bin.000123` cannot verify install. `cmd/binlogviz/testdata/minimal.binlog` is a real 1500-byte ROW fixture and was not linked.
- **#11** is right. `analyze --help` has `--details --show-minutes --show-patterns --top --detail-store`; the CLI Flags table omitted them.
- **#21** is text IA, not HTML. Default text was Findings-first (including synthesized `[critical] Write spike`). DBA first screen should be hot tables + largest txns.
- **#20** is right. `selectRepresentativeTxns` ignored `patternKey` and picked the global largest txns, so a DELETE large-batch drilldown could list 400k-row INSERTs. `%.0f` also rounded a 0.3% txn share to `0%`. Streaming finalize only kept the global top-5 largest txns, so even after filtering we have to retain per-pattern reps.

## Changes

### Site / install / docs (#4, #10, #11, #22)

- Landing page current release is `v0.21.0`. Homebrew is labeled **macOS-only**. Linux gets `install.sh --version v0.21.0` plus the linux tarball path. First analyze command downloads `minimal.binlog`.
- `install.sh` example tag is `v0.21.0`.
- README / Quickstart first screen states capability boundaries: fast ROW summary; STATEMENT/MIXED empty or undercount; positions are file evidence — use as `mysqlbinlog --start-position` only when the span covers txn events, not an XID-only interval (does not claim they never work; #29 is reconstructing spans).
- First command is the downloadable sample. `.goreleaser.yml` will attach `testdata/minimal.binlog` on the next tagged release.
- CLI Reference Flags table adds `--top --details --show-minutes --show-patterns --detail-store` plus `binlogviz analyze mysql-bin.000123 --details --show-minutes --show-patterns`.

**Out of scope:** deploying Cloudflare Pages itself (config is outside this repo). After merge, the site update depends on whatever publishes `docs/landing/index.html` to https://binlogviz.pages.dev. Attaching the sample to the already-published `v0.21.0` GitHub release is also out of scope here.

### Text report IA (#21)

Default text order is now:

1. Summary (time range, ROW/logical-row format line, txn/rows/events, largest txn bytes)
2. Top Tables
3. Top Transactions (up to 3 largest, plus longest/widest champions)
4. Findings (unchanged synthesis — #27 owns threshold/JSON parity)
5. Activity / Next Actions

HTML is unchanged.

### Write-shape reps (#20)

- `representative_transactions` must share the pattern identity (same tables + ops + shape).
- Aggregator keeps a bounded per-pattern top-2 so DELETE large-batch still has its own evidence, not just the 400k INSERTs in the global largest list.
- Sub-1% shares print as `0.3%`, not `0%`.

## Tests

- `TestSelectRepresentativeTxnsBelongToSamePattern`
- `TestFormatSharePercentKeepsSubOnePercent`
- `TestReportAggregatorDeletePatternDoesNotCiteInsertTxns`
- `TestRenderTextIncidentBriefPutsTablesAndTxnsBeforeFindings`
- `TestRenderTextShowsUpToThreeLargestTransactions`

```bash
go test ./internal/analyzer/ ./internal/report/ ./cmd/binlogviz/ -count=1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4f9ae1a-c1a6-4bc5-b207-a5658fef5f14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4f9ae1a-c1a6-4bc5-b207-a5658fef5f14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

